### PR TITLE
Dshunit

### DIFF
--- a/dshUnit/AssertNoErrorTests.sh
+++ b/dshUnit/AssertNoErrorTests.sh
@@ -3,32 +3,19 @@
 
 set -o posix
 
-testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected() {
-    local initial_passes numberOfAssertions
-    numberOfAssertions="3"
-    initial_passes="${PASSING_ASSERTIONS}"
-    showRunningTestMsg "testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected"
-    assertNoError "ls" "assertNoError MUST run without error on system command ${HIGHLIGHTCOLOR}ls${NOTIFY_COLOR}."
-    assertNoError "pwd" "assertNoError MUST run without error on system command ${HIGHLIGHTCOLOR}pwd${NOTIFY_COLOR}."
-    assertNoError "assertNoError ls 'Test message'" "assertNoError MUST run without error on itself."
-    [[ "$((initial_passes + numberOfAssertions))" == "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
-    increaseFailingTests
+testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected() {
+    showRunningTestMsg "testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected"
+    assertNoError "assertNoError ls 'Test message'" "assertNoError MUST run without error"
+    [[ $? -gt 0 ]] && increaseFailingTests && return
+    increasePassingTests
 }
 
-testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected
-
-testAssertNoErrorRunsWithErrorWhenFailingAssertionIsExpected() {
-    local initial_fails numberOfAssertions
-    numberOfAssertions="2"
-    initial_fails="${FAILING_ASSERTIONS}"
-    showRunningTestMsg "testAssertNoErrorRunsWithErrorWhenFailingAssertionIsExpected"
-    assertNoError "ls some/dir/that/does/not/exist/${RANDOM}" "Expecting an error, and a failed assertion."
-    assertNoError "printf \"%s%29.5'%%s\" \"Foo\" \"bar\"" "Expecting an error, and a failed assertion."
-    [[ "$((initial_fails + numberOfAssertions))" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
-    increaseFailingTests
+testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected() {
+    showRunningTestMsg "testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected"
+    assertNoError "${RANDOM}${RANDOM}Foo" "assertError MUST not produce any errors on a failing assertion, rather errors produced by the command passed to assertError should be captured and displayed in dshUnit's UI."
+    [[ $? -gt 0 ]] && increaseFailingTests && return
+    increasePassingTests
 }
-
-testAssertNoErrorRunsWithErrorWhenFailingAssertionIsExpected
 
 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
     local initial_passes
@@ -38,8 +25,6 @@ testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
     [[ "${initial_passes}" -lt "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
     increaseFailingTests
 }
-
-testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion
 
 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
     local initial_fails initial_passes
@@ -51,5 +36,8 @@ testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
     increaseFailingTests
 }
 
+testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected
+testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected
+testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion
 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion
 

--- a/dshUnit/AssertNoErrorTests.sh
+++ b/dshUnit/AssertNoErrorTests.sh
@@ -3,11 +3,11 @@
 
 set -o posix
 
-testAssertNoErrorIndicatesPassingTestForCommandsThatAreExpectedToPass() {
+testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected() {
     local initial_passes numberOfAssertions
     numberOfAssertions="3"
     initial_passes="${PASSING_ASSERTIONS}"
-    showRunningTestMsg "testAssertNoErrorIndicatesPassingTestForCommandsThatAreExpectedToPass"
+    showRunningTestMsg "testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected"
     assertNoError "ls" "assertNoError MUST run without error on system command ${HIGHLIGHTCOLOR}ls${NOTIFY_COLOR}."
     assertNoError "pwd" "assertNoError MUST run without error on system command ${HIGHLIGHTCOLOR}pwd${NOTIFY_COLOR}."
     assertNoError "assertNoError ls '${test_msg}'" "assertNoError MUST run without error on itself."
@@ -15,7 +15,7 @@ testAssertNoErrorIndicatesPassingTestForCommandsThatAreExpectedToPass() {
     increaseFailingTests
 }
 
-testAssertNoErrorIndicatesPassingTestForCommandsThatAreExpectedToPass
+testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected
 
 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
     local initial_passes

--- a/dshUnit/AssertNoErrorTests.sh
+++ b/dshUnit/AssertNoErrorTests.sh
@@ -10,20 +10,32 @@ testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected() {
     showRunningTestMsg "testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected"
     assertNoError "ls" "assertNoError MUST run without error on system command ${HIGHLIGHTCOLOR}ls${NOTIFY_COLOR}."
     assertNoError "pwd" "assertNoError MUST run without error on system command ${HIGHLIGHTCOLOR}pwd${NOTIFY_COLOR}."
-    assertNoError "assertNoError ls '${test_msg}'" "assertNoError MUST run without error on itself."
+    assertNoError "assertNoError ls 'Test message'" "assertNoError MUST run without error on itself."
     [[ "$((initial_passes + numberOfAssertions))" == "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
     increaseFailingTests
 }
 
 testAssertNoErrorRunsWithoutErrorWhenPassingAssertionIsExpected
 
+testAssertNoErrorRunsWithErrorWhenFailingAssertionIsExpected() {
+    local initial_fails numberOfAssertions
+    numberOfAssertions="2"
+    initial_fails="${FAILING_ASSERTIONS}"
+    showRunningTestMsg "testAssertNoErrorRunsWithErrorWhenFailingAssertionIsExpected"
+    assertNoError "ls some/dir/that/does/not/exist/${RANDOM}" "Expecting an error, and a failed assertion."
+    assertNoError "printf \"%s%29.5'%%s\" \"Foo\" \"bar\"" "Expecting an error, and a failed assertion."
+    [[ "$((initial_fails + numberOfAssertions))" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertNoErrorRunsWithErrorWhenFailingAssertionIsExpected
+
 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
     local initial_passes
     initial_passes="${PASSING_ASSERTIONS}"
     showRunningTestMsg "testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion"
     assertNoError 'echo There should not be any errors and PASSING_ASSERTIONS MUST increase' "assertNoError MUST increase the number of PASSING_ASSERTIONS on passing assertion."
-    notifyUser "${HIGHLIGHTCOLOR}Note: The previous call to assertNoError's results will not be tracked, it was just used to test that PASSING_ASSERTIONS are increased by assertNoError on a pssing assertion." 0 'dontClear'
-    [[ "${initial_passes}" -lt "${PASSING_ASSERTIONS}" ]] && increasePassingTests && PASSING_ASSERTIONS="${initial_passes}" && return
+    [[ "${initial_passes}" -lt "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
     increaseFailingTests
 }
 
@@ -35,8 +47,7 @@ testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
     initial_fails="${FAILING_ASSERTIONS}"
     showRunningTestMsg "testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion"
     assertNoError '${RANDOM}' "assertNoError MUST increase the number of FAILING_ASSERTIONS on failing assertion."
-    notifyUser "${HIGHLIGHTCOLOR}Note: The previous call to assertNoError's results will not be tracked, it was just used to test that FAILING_ASSERTIONS are increased by assertNoError on a failing assertion." 0 'dontClear'
-    [[ "${initial_fails}" -lt "${FAILING_ASSERTIONS}" ]] && increasePassingTests && FAILING_ASSERTIONS="${initial_fails}" && return
+    [[ "${initial_fails}" -lt "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
     increaseFailingTests
 }
 

--- a/dshUnit/dshUnitAssertions.sh
+++ b/dshUnit/dshUnitAssertions.sh
@@ -5,8 +5,6 @@ set -o posix
 
 assertNoError() {
     local initial_passes initial_fails error
-    initial_passes="${PASSING_ASSERTIONS}"
-    initial_fails="${FAILING_ASSERTIONS}"
     showAssertionMsg "assertNoError" "${1}" "${2}"
     error="$( ${1} 2>&1 1>/dev/null)"
     [[ $? -eq 0 ]] && increasePassingAssertions && return


### PR DESCRIPTION
assertNoError has been implemented and the following tests have been implemented to test assertNoError

```
testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected()
testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected()
testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion()
testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion()
```
assertNoError tests that no errors are produced by a specified command.

Usage:
`assertNoError <COMMAND> <MESSAGE>`

