### PR TITLE
Implemented dshUnitAssertions.sh::AssertErrorIfDirectoryDoesNotExist().

### DIFF
--- a/dshUnit/AssertErrorIfDirectoryDoesNotExistTests.sh
+++ b/dshUnit/AssertErrorIfDirectoryDoesNotExistTests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# AssertErrorIfDirectoryDoesNotExistTests.sh
+
+set -o posix
+
+testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected() {
+    local initial_fails random_directory_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_directory_path="${RANDOM}/${RANDOM}/Foo${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected"
+    assertNoError "assertErrorIfDirectoryDoesNotExist \"echo ${random_directory_path}\" \"${random_directory_path}\" 'Test message'" "assertErrorIfDirectoryDoesNotExist MUST run without error when failing assertion is expected."
+    [[ "${initial_fails}" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected() {
+    local initial_fails random_directory_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_directory_path="${RANDOM}/${RANDOM}/Bar${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected"
+    assertNoError "assertErrorIfDirectoryDoesNotExist \"ls ${random_directory_path}\" \"${random_directory_path}\" 'Test message'" "assertErrorIfDirectoryDoesNotExist MUST run without error when passing assertion is expected."
+    [[ "${initial_fails}" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increasePassingTests
+}
+
+testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
+    local initial_passes random_directory_path
+    initial_passes="${PASSING_ASSERTIONS}"
+    random_directory_path="${RANDOM}/Foo${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion"
+    assertErrorIfDirectoryDoesNotExist "ls ${random_directory_path}" "${random_directory_path}" "assertErrorIfDirectoryDoesNotExist MUST increase the number of PASSING_ASSERTIONS on passing assertion."
+    [[ "${initial_passes}" -lt "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
+    local initial_fails random_directory_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_directory_path="${RANDOM}/Bar${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion"
+    assertErrorIfDirectoryDoesNotExist "echo ${random_directory_path}" "${random_directory_path}" "assertErrorIfDirectoryDoesNotExist MUST increase the number of FAILING_ASSERTIONS on failing assertion."
+    [[ "${initial_fails}" -lt "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected
+testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected
+testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion
+testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion

--- a/dshUnit/dshUnitAssertions.sh
+++ b/dshUnit/dshUnitAssertions.sh
@@ -39,3 +39,11 @@ assertErrorIfFileExists() {
     showErrorOccurredMsg "${LAST_CAPTURED_ERROR_MSG:-NO_MESSAGE}"
     increasePassingAssertions
 }
+
+assertErrorIfDirectoryDoesNotExist() {
+    showAssertionMsg "assertErrorIfDirectoryDoesNotExist" "${1}" "${3}"
+    captureError "${1}"
+    [[ "${CURRENT_ERROR_COUNT:-0}" -eq 0 ]] && [[ ! -d "${2}" ]] && increaseFailedAssertions && return
+    showErrorOccurredMsg "${LAST_CAPTURED_ERROR_MSG:-NO_MESSAGE}"
+    increasePassingAssertions
+}

--- a/dshUnit/dshUnitConfig.sh
+++ b/dshUnit/dshUnitConfig.sh
@@ -18,3 +18,7 @@ fi
 if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertErrorIfFileExists' ]]; then
     . "$(determineDshUnitDirectoryPath)/AssertErrorIfFileExistsTests.sh"
 fi
+
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertErrorIfDirectoryDoesNotExist' ]]; then
+    . "$(determineDshUnitDirectoryPath)/AssertErrorIfDirectoryDoesNotExistTests.sh"
+fi


### PR DESCRIPTION
 Implemented `dshUnitAssertions.sh::AssertErrorIfDirectoryDoesNotExist()`.

Implemented the following tests for `dshUnitAssertions.sh::assertErrorIfDirectoryDoesNotExist()`:

```
testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected
testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected
testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion
testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion
```

All dshUnit tests are passing.

This commit is related to issue #26.