### PR TITLE
dshUnit: Implemented dshUnitAssertions.sh::assertErrorIfFileIsNotExecutable()

### DIFF
--- a/dshUnit/AssertErrorIfFileIsNotExecutable.sh
+++ b/dshUnit/AssertErrorIfFileIsNotExecutable.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# AssertErrorIfFileIsNotExecutableTests.sh
+
+set -o posix
+
+testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected() {
+    local initial_faicat random_file_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_file_path="${RANDOM}/${RANDOM}/Foo${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected"
+    assertNoError "assertErrorIfFileIsNotExecutable \"echo ${random_file_path}\" \"${random_file_path}\" 'Test message'" "assertErrorIfFileIsNotExecutable MUST run without error when failing assertion is expected."
+    [[ "${initial_fails}" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected() {
+    local initial_faicat random_file_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_file_path="${RANDOM}/${RANDOM}/Bar${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected"
+    assertNoError "assertErrorIfFileIsNotExecutable \"cat ${random_file_path}\" \"${random_file_path}\" 'Test message'" "assertErrorIfFileIsNotExecutable MUST run without error when passing assertion is expected."
+    [[ "${initial_fails}" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increasePassingTests
+}
+
+testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
+    local initial_passes random_file_path
+    initial_passes="${PASSING_ASSERTIONS}"
+    random_file_path="${RANDOM}/Foo${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion"
+    assertErrorIfFileIsNotExecutable "cat ${random_file_path}" "${random_file_path}" "assertErrorIfFileIsNotExecutable MUST increase the number of PASSING_ASSERTIONS on passing assertion."
+    [[ "${initial_passes}" -lt "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
+    local initial_faicat random_file_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_file_path="${RANDOM}/Bar${RANDOM}"
+    showRunningTestMsg "testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion"
+    assertErrorIfFileIsNotExecutable "echo ${random_file_path}" "${random_file_path}" "assertErrorIfFileIsNotExecutable MUST increase the number of FAILING_ASSERTIONS on failing assertion."
+    [[ "${initial_fails}" -lt "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected
+testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected
+testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion
+testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion
+
+

--- a/dshUnit/dshUnitAssertions.sh
+++ b/dshUnit/dshUnitAssertions.sh
@@ -56,3 +56,10 @@ assertErrorIfFileDoesNotExist() {
     increasePassingAssertions
 }
 
+assertErrorIfFileIsNotExecutable() {
+    showAssertionMsg "assertErrorIfFileIsNotExecutable" "${1}" "${3}"
+    captureError "${1}"
+    [[ "${CURRENT_ERROR_COUNT:-0}" -eq 0 ]] && [[ ! -x "${2}" ]] && increaseFailedAssertions && return
+    showErrorOccurredMsg "${LAST_CAPTURED_ERROR_MSG:-NO_MESSAGE}"
+    increasePassingAssertions
+}

--- a/dshUnit/dshUnitConfig.sh
+++ b/dshUnit/dshUnitConfig.sh
@@ -26,3 +26,7 @@ fi
 if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertErrorIfFileDoesNotExist' ]]; then
     . "$(determineDshUnitDirectoryPath)/AssertErrorIfFileDoesNotExistTests.sh"
 fi
+
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertErrorIfFileIsNotExecutable' ]]; then
+    . "$(determineDshUnitDirectoryPath)/AssertErrorIfFileIsNotExecutable.sh"
+fi


### PR DESCRIPTION
dshUnit: Implemented `dshUnitAssertions.sh::assertErrorIfFileIsNotExecutable()`

Implemented the following test for `dshUnitAssertions::assertErrorIfFileIsNotExecutable()`:
```

testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected()
testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected()
testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion() 
testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion()
```

All dshUnit tests are passing.

This commit is related to issue #26.