### PR TITLE
Dshunit

### DIFF
--- a/dshUnit/AssertDirectoryExistsTests.sh
+++ b/dshUnit/AssertDirectoryExistsTests.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# AssertDirectoryExistsTests.sh
+
+set -o posix
+
+testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected() {
+    local initial_fails random_directory_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_directory_path="${RANDOM}/${RANDOM}/FooBar${RANDOM}"
+    showRunningTestMsg "testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected"
+    assertNoError "assertDirectoryExists \"ls ${random_directory_path}\" \"${random_directory_path}\" 'Test message'" "assertDirectoryExists MUST run without error when failing assertion is expected."
+    [[ "${initial_fails}" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected() {
+    local initial_fails
+    initial_fails="${FAILING_ASSERTIONS}"
+    showRunningTestMsg "testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected"
+    assertNoError "assertDirectoryExists \"ls $(determineDshUnitDirectoryPath)\" \"$(determineDshUnitDirectoryPath)\" 'Test message'" "assertDirectoryExists MUST run without error when passing assertion is expected."
+    [[ "${initial_fails}" == "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increasePassingTests
+}
+
+testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
+    local initial_passes
+    initial_passes="${PASSING_ASSERTIONS}"
+    showRunningTestMsg "testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion"
+    assertDirectoryExists "ls $(determineDshUnitDirectoryPath)" "$(determineDshUnitDirectoryPath)" "assertDirectoryExists MUST increase the number of PASSING_ASSERTIONS on passing assertion."
+    [[ "${initial_passes}" -lt "${PASSING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
+    local initial_fails random_directory_path
+    initial_fails="${FAILING_ASSERTIONS}"
+    random_directory_path="${RANDOM}/FooBar${RANDOM}"
+    showRunningTestMsg "testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion"
+    assertDirectoryExists "ls ${random_directory_path}" "${random_directory_path}" "assertDirectoryExists MUST increase the number of FAILING_ASSERTIONS on failing assertion."
+    [[ "${initial_fails}" -lt "${FAILING_ASSERTIONS}" ]] && increasePassingTests && return
+    increaseFailingTests
+}
+
+testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected
+testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected
+testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion
+testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion
+

--- a/dshUnit/dshUnit
+++ b/dshUnit/dshUnit
@@ -1,4 +1,5 @@
 #!/bin/bash
+# dshUnit
 
 set -o posix
 

--- a/dshUnit/dshUnitAssertions.sh
+++ b/dshUnit/dshUnitAssertions.sh
@@ -63,3 +63,11 @@ assertErrorIfFileIsNotExecutable() {
     showErrorOccurredMsg "${LAST_CAPTURED_ERROR_MSG:-NO_MESSAGE}"
     increasePassingAssertions
 }
+
+assertDirectoryExists() {
+    showAssertionMsg "assertDirectoryExists" "${1}" "${3}"
+    captureError "${1}"
+    [[ "${CURRENT_ERROR_COUNT:-0}" -gt 0 ]] && showErrorOccurredMsg "${LAST_CAPTURED_ERROR_MSG:-NO_MESSAGE}"
+    [[ -d "${2}" ]] && increasePassingAssertions
+    increaseFailedAssertions
+}

--- a/dshUnit/dshUnitConfig.sh
+++ b/dshUnit/dshUnitConfig.sh
@@ -30,3 +30,7 @@ fi
 if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertErrorIfFileIsNotExecutable' ]]; then
     . "$(determineDshUnitDirectoryPath)/AssertErrorIfFileIsNotExecutable.sh"
 fi
+
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertDirectoryExists' ]]; then
+    . "$(determineDshUnitDirectoryPath)/AssertDirectoryExistsTests.sh"
+fi


### PR DESCRIPTION
 dshUnit: Implemented `dshUnitAssertions.sh::assertDirectoryExists()`.

Implemented the following tests for `dshUnitAssertions.sh::assertDirectoryExists()`:

```
testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected
testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected
testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion
testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion

```
All dshUnit tests are passing.

This is related to issue #26.