### PR TITLE
Dshunit

### DIFF
--- a/dshUnit/AssertEqualsTests.sh
+++ b/dshUnit/AssertEqualsTests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# AssertEqualsTests.sh
+
+set -o posix
+
+testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected() {
+    assertNoError "assertEquals 'Foo' 'Bar' 'Test message'" "assertEquals MUST run without error when failing assertion is expected."
+}
+
+testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected() {
+    assertNoError "assertEquals 'Foo' 'Foo' 'Test message'" "assertEquals MUST run without error when failing assertion is expected."
+}
+
+testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
+    assertEquals 'Foo' 'Foo' "assertEquals MUST run without error when failing assertion is expected."
+}
+
+testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
+    assertEquals 'Foo' 'Bar' "assertEquals MUST run without error when failing assertion is expected."
+}
+
+runTest testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected "1"
+runTest testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected "1"
+runTest testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion
+runTest testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion "1" "allAssertionsFail"
+

--- a/dshUnit/AssertNotEqualsTests.sh
+++ b/dshUnit/AssertNotEqualsTests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# AssertNotEqualsTests.sh
+
+set -o posix
+
+testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected() {
+    assertNoError "assertNotEquals 'Bar' 'Bar' 'Test message'" "assertNotEquals MUST run without error when failing assertion is expected."
+}
+
+testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected() {
+    assertNoError "assertNotEquals 'Bar' 'Foo' 'Test message'" "assertNotEquals MUST run without error when failing assertion is expected."
+}
+
+testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion() {
+    assertNotEquals 'Bar' 'Foo' "assertNotEquals MUST run without error when failing assertion is expected."
+}
+
+testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion() {
+    assertNotEquals 'Bar' 'Bar' "assertNotEquals MUST run without error when failing assertion is expected."
+}
+
+runTest testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected "1"
+runTest testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected "1"
+runTest testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion
+runTest testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion "1" "allAssertionsFail"
+

--- a/dshUnit/dshUnitAssertions.sh
+++ b/dshUnit/dshUnitAssertions.sh
@@ -95,3 +95,15 @@ assertFileDoesNotExist() {
     [[ ! -f "${2}" ]] && increasePassingAssertions "assertFileDoesNotExist" && return
     increaseFailedAssertions "assertFileDoesNotExist"
 }
+
+assertEquals() {
+    showAssertionMsg "assertEquals" "${1}" "${3}"
+    [[ "${1}" == "${2}" ]] && increasePassingAssertions "assertEquals" && return
+    increaseFailedAssertions "assertEquals"
+}
+
+assertNotEquals() {
+    showAssertionMsg "assertNotEquals" "${1}" "${3}"
+    [[ "${1}" != "${2}" ]] && increasePassingAssertions "assertNotEquals" && return
+    increaseFailedAssertions "assertNotEquals"
+}

--- a/dshUnit/dshUnitConfig.sh
+++ b/dshUnit/dshUnitConfig.sh
@@ -47,4 +47,12 @@ if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'Test
     . "$(determineDshUnitDirectoryPath)/AssertFileDoesNotExistTests.sh"
 fi
 
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertEquals' ]]; then
+    . "$(determineDshUnitDirectoryPath)/AssertEqualsTests.sh"
+fi
+
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestAssertNotEquals' ]]; then
+    . "$(determineDshUnitDirectoryPath)/AssertNotEqualsTests.sh"
+fi
+
 

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,167 +1,195 @@
 
 
-[0m[44m[30mThu Dec 10 05:09:29 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mThu Dec 10 05:09:30 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:09:34 PM EST 2020 testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:06:40 PM EST 2020 assertNoError Passed[0m
+[0m[44m[30mThu Dec 10 06:06:42 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:06:46 PM EST 2020 testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 05:09:48 PM EST 2020 assertNoError Failed[0m
-[0m[44m[30mThu Dec 10 05:09:50 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:09:54 PM EST 2020 testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:06:58 PM EST 2020 assertNoError Failed[0m
+[0m[44m[30mThu Dec 10 06:06:59 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:07:03 PM EST 2020 testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:10:01 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mThu Dec 10 05:10:06 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mThu Dec 10 05:10:11 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:10:15 PM EST 2020 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:07:10 PM EST 2020 assertNoError Passed[0m
+[0m[44m[30mThu Dec 10 06:07:14 PM EST 2020 assertNoError Passed[0m
+[0m[44m[30mThu Dec 10 06:07:18 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:07:22 PM EST 2020 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:10:26 PM EST 2020 assertNoError Failed[0m
-[0m[43m[30mThu Dec 10 05:10:34 PM EST 2020 assertNoError Failed[0m
-[0m[43m[30mThu Dec 10 05:10:41 PM EST 2020 assertNoError Failed[0m
-[0m[104m[30mThu Dec 10 05:10:45 PM EST 2020 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:07:32 PM EST 2020 assertNoError Failed[0m
+[0m[43m[30mThu Dec 10 06:07:39 PM EST 2020 assertNoError Failed[0m
+[0m[43m[30mThu Dec 10 06:07:45 PM EST 2020 assertNoError Failed[0m
+[0m[104m[30mThu Dec 10 06:07:49 PM EST 2020 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:10:55 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 05:10:56 PM EST 2020 assertNoError Passed[0m
-[0m[43m[30mThu Dec 10 05:11:04 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 05:11:05 PM EST 2020 assertNoError Passed[0m
-[0m[43m[30mThu Dec 10 05:11:12 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 05:11:13 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:11:17 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:07:57 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 06:07:58 PM EST 2020 assertNoError Passed[0m
+[0m[43m[30mThu Dec 10 06:08:03 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 06:08:05 PM EST 2020 assertNoError Passed[0m
+[0m[43m[30mThu Dec 10 06:08:10 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 06:08:11 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:08:15 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 05:11:27 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 05:11:28 PM EST 2020 assertNoError Passed[0m
-[0m[43m[30mThu Dec 10 05:11:36 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 05:11:37 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:11:41 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:08:23 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 06:08:24 PM EST 2020 assertNoError Passed[0m
+[0m[43m[30mThu Dec 10 06:08:30 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 06:08:31 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:08:35 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:11:52 PM EST 2020 assertError Passed[0m
-[0m[104m[30mThu Dec 10 05:11:56 PM EST 2020 testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:08:44 PM EST 2020 assertError Passed[0m
+[0m[104m[30mThu Dec 10 06:08:48 PM EST 2020 testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:12:03 PM EST 2020 assertError Failed[0m
-[0m[43m[30mThu Dec 10 05:12:08 PM EST 2020 assertError Failed[0m
-[0m[43m[30mThu Dec 10 05:12:14 PM EST 2020 assertError Failed[0m
-[0m[104m[30mThu Dec 10 05:12:17 PM EST 2020 testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:08:55 PM EST 2020 assertError Failed[0m
+[0m[43m[30mThu Dec 10 06:08:59 PM EST 2020 assertError Failed[0m
+[0m[43m[30mThu Dec 10 06:09:03 PM EST 2020 assertError Failed[0m
+[0m[104m[30mThu Dec 10 06:09:07 PM EST 2020 testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:12:33 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
-[0m[44m[30mThu Dec 10 05:12:34 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:12:38 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:09:21 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
+[0m[44m[30mThu Dec 10 06:09:22 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:09:26 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:12:54 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
-[0m[44m[30mThu Dec 10 05:12:55 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:12:59 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:09:41 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
+[0m[44m[30mThu Dec 10 06:09:42 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:09:47 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:13:11 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
-[0m[104m[30mThu Dec 10 05:13:15 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:09:57 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
+[0m[104m[30mThu Dec 10 06:10:02 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:13:23 PM EST 2020 assertErrorIfDirectoryExists Failed[0m
-[0m[104m[30mThu Dec 10 05:13:28 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:10:10 PM EST 2020 assertErrorIfDirectoryExists Failed[0m
+[0m[104m[30mThu Dec 10 06:10:14 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:13:43 PM EST 2020 assertErrorIfFileExists Passed[0m
-[0m[44m[30mThu Dec 10 05:13:44 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:13:49 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:10:28 PM EST 2020 assertErrorIfFileExists Passed[0m
+[0m[44m[30mThu Dec 10 06:10:29 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:10:34 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:14:04 PM EST 2020 assertErrorIfFileExists Passed[0m
-[0m[44m[30mThu Dec 10 05:14:05 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:14:10 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:10:48 PM EST 2020 assertErrorIfFileExists Passed[0m
+[0m[44m[30mThu Dec 10 06:10:49 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:10:54 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:14:21 PM EST 2020 assertErrorIfFileExists Passed[0m
-[0m[104m[30mThu Dec 10 05:14:25 PM EST 2020 testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:11:05 PM EST 2020 assertErrorIfFileExists Passed[0m
+[0m[104m[30mThu Dec 10 06:11:09 PM EST 2020 testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:14:33 PM EST 2020 assertErrorIfFileExists Failed[0m
-[0m[104m[30mThu Dec 10 05:14:37 PM EST 2020 testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:11:16 PM EST 2020 assertErrorIfFileExists Failed[0m
+[0m[104m[30mThu Dec 10 06:11:21 PM EST 2020 testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:14:52 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:14:53 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:14:58 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:11:34 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:11:35 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:11:40 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:15:12 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:15:13 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:15:18 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:11:53 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:11:54 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:11:59 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:15:29 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 05:15:34 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:12:09 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 06:12:14 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:15:42 PM EST 2020 assertErrorIfDirectoryDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 05:15:47 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:12:22 PM EST 2020 assertErrorIfDirectoryDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 06:12:26 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:16:01 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:16:02 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:16:07 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:12:39 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:12:40 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:12:45 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:16:21 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:16:22 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:16:27 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:12:58 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:12:59 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:13:04 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:16:37 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 05:16:42 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:13:13 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 06:13:18 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:16:50 PM EST 2020 assertErrorIfFileDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 05:16:55 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:13:25 PM EST 2020 assertErrorIfFileDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 06:13:30 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:17:09 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[44m[30mThu Dec 10 05:17:10 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:17:15 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:13:43 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[44m[30mThu Dec 10 06:13:44 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:13:48 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:17:29 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[44m[30mThu Dec 10 05:17:30 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:17:35 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:14:01 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[44m[30mThu Dec 10 06:14:03 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:14:07 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:17:46 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[104m[30mThu Dec 10 05:17:50 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:14:17 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[104m[30mThu Dec 10 06:14:22 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:17:59 PM EST 2020 assertErrorIfFileIsNotExecutable Failed[0m
-[0m[104m[30mThu Dec 10 05:18:03 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:14:29 PM EST 2020 assertErrorIfFileIsNotExecutable Failed[0m
+[0m[104m[30mThu Dec 10 06:14:34 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:18:17 PM EST 2020 assertDirectoryExists Failed[0m
-[0m[44m[30mThu Dec 10 05:18:18 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:18:23 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:14:46 PM EST 2020 assertDirectoryExists Failed[0m
+[0m[44m[30mThu Dec 10 06:14:47 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:14:52 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 05:18:38 PM EST 2020 assertDirectoryExists Failed[0m
-[0m[44m[30mThu Dec 10 05:18:39 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:18:43 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:15:06 PM EST 2020 assertDirectoryExists Failed[0m
+[0m[44m[30mThu Dec 10 06:15:07 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:15:11 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:18:51 PM EST 2020 assertDirectoryExists Passed[0m
-[0m[104m[30mThu Dec 10 05:18:55 PM EST 2020 testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:15:18 PM EST 2020 assertDirectoryExists Passed[0m
+[0m[104m[30mThu Dec 10 06:15:23 PM EST 2020 testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:19:06 PM EST 2020 assertDirectoryExists Failed[0m
-[0m[104m[30mThu Dec 10 05:19:10 PM EST 2020 testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:15:32 PM EST 2020 assertDirectoryExists Failed[0m
+[0m[104m[30mThu Dec 10 06:15:36 PM EST 2020 testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:19:25 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:19:26 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:19:31 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:15:51 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:15:52 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:15:56 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:19:45 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:19:46 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:19:51 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:16:09 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:16:10 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:16:15 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:20:02 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 05:20:06 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:16:24 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 06:16:29 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:20:14 PM EST 2020 assertDirectoryDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 05:20:18 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:16:37 PM EST 2020 assertDirectoryDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 06:16:41 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:20:32 PM EST 2020 assertFileExists Failed[0m
-[0m[44m[30mThu Dec 10 05:20:33 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:20:38 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:16:53 PM EST 2020 assertFileExists Failed[0m
+[0m[44m[30mThu Dec 10 06:16:54 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:16:59 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 05:20:53 PM EST 2020 assertFileExists Failed[0m
-[0m[44m[30mThu Dec 10 05:20:54 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:20:58 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 06:17:13 PM EST 2020 assertFileExists Failed[0m
+[0m[44m[30mThu Dec 10 06:17:14 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:17:18 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:21:06 PM EST 2020 assertFileExists Passed[0m
-[0m[104m[30mThu Dec 10 05:21:10 PM EST 2020 testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:17:25 PM EST 2020 assertFileExists Passed[0m
+[0m[104m[30mThu Dec 10 06:17:29 PM EST 2020 testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:21:20 PM EST 2020 assertFileExists Failed[0m
-[0m[104m[30mThu Dec 10 05:21:24 PM EST 2020 testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:17:38 PM EST 2020 assertFileExists Failed[0m
+[0m[104m[30mThu Dec 10 06:17:42 PM EST 2020 testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 05:21:39 PM EST 2020 assertFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:21:40 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:21:45 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:17:57 PM EST 2020 assertFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:17:58 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:18:02 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:21:59 PM EST 2020 assertFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 05:22:00 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 05:22:04 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 06:18:15 PM EST 2020 assertFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 06:18:16 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:18:20 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 05:22:14 PM EST 2020 assertFileDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 05:22:19 PM EST 2020 testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 06:18:30 PM EST 2020 assertFileDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 06:18:34 PM EST 2020 testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 05:22:26 PM EST 2020 assertFileDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 05:22:31 PM EST 2020 testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 06:18:41 PM EST 2020 assertFileDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 06:18:46 PM EST 2020 testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[43m[30mThu Dec 10 06:18:54 PM EST 2020 assertEquals Failed[0m
+[0m[44m[30mThu Dec 10 06:18:55 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:18:59 PM EST 2020 testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30mThu Dec 10 06:19:07 PM EST 2020 assertEquals Passed[0m
+[0m[44m[30mThu Dec 10 06:19:08 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:19:12 PM EST 2020 testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30mThu Dec 10 06:19:18 PM EST 2020 assertEquals Passed[0m
+[0m[104m[30mThu Dec 10 06:19:22 PM EST 2020 testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[43m[30mThu Dec 10 06:19:29 PM EST 2020 assertEquals Failed[0m
+[0m[104m[30mThu Dec 10 06:19:33 PM EST 2020 testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[43m[30mThu Dec 10 06:19:41 PM EST 2020 assertNotEquals Failed[0m
+[0m[44m[30mThu Dec 10 06:19:42 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:19:46 PM EST 2020 testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30mThu Dec 10 06:19:54 PM EST 2020 assertNotEquals Passed[0m
+[0m[44m[30mThu Dec 10 06:19:55 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 06:20:00 PM EST 2020 testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30mThu Dec 10 06:20:06 PM EST 2020 assertNotEquals Passed[0m
+[0m[104m[30mThu Dec 10 06:20:10 PM EST 2020 testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[43m[30mThu Dec 10 06:20:16 PM EST 2020 assertNotEquals Failed[0m
+[0m[104m[30mThu Dec 10 06:20:20 PM EST 2020 testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,195 +1,195 @@
 
 
-[0m[44m[30mThu Dec 10 06:06:40 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mThu Dec 10 06:06:42 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:06:46 PM EST 2020 testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:37:45 PM EST 2020 assertNoError Passed[0m
+[0m[44m[30mThu Dec 10 07:37:46 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:37:50 PM EST 2020 testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 06:06:58 PM EST 2020 assertNoError Failed[0m
-[0m[44m[30mThu Dec 10 06:06:59 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:07:03 PM EST 2020 testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:38:05 PM EST 2020 assertNoError Failed[0m
+[0m[44m[30mThu Dec 10 07:38:06 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:38:11 PM EST 2020 testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:07:10 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mThu Dec 10 06:07:14 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mThu Dec 10 06:07:18 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:07:22 PM EST 2020 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:38:18 PM EST 2020 assertNoError Passed[0m
+[0m[44m[30mThu Dec 10 07:38:23 PM EST 2020 assertNoError Passed[0m
+[0m[44m[30mThu Dec 10 07:38:27 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:38:31 PM EST 2020 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:07:32 PM EST 2020 assertNoError Failed[0m
-[0m[43m[30mThu Dec 10 06:07:39 PM EST 2020 assertNoError Failed[0m
-[0m[43m[30mThu Dec 10 06:07:45 PM EST 2020 assertNoError Failed[0m
-[0m[104m[30mThu Dec 10 06:07:49 PM EST 2020 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:38:42 PM EST 2020 assertNoError Failed[0m
+[0m[43m[30mThu Dec 10 07:38:49 PM EST 2020 assertNoError Failed[0m
+[0m[43m[30mThu Dec 10 07:38:56 PM EST 2020 assertNoError Failed[0m
+[0m[104m[30mThu Dec 10 07:39:00 PM EST 2020 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:07:57 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 06:07:58 PM EST 2020 assertNoError Passed[0m
-[0m[43m[30mThu Dec 10 06:08:03 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 06:08:05 PM EST 2020 assertNoError Passed[0m
-[0m[43m[30mThu Dec 10 06:08:10 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 06:08:11 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:08:15 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:39:10 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 07:39:11 PM EST 2020 assertNoError Passed[0m
+[0m[43m[30mThu Dec 10 07:39:18 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 07:39:19 PM EST 2020 assertNoError Passed[0m
+[0m[43m[30mThu Dec 10 07:39:27 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 07:39:28 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:39:32 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 06:08:23 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 06:08:24 PM EST 2020 assertNoError Passed[0m
-[0m[43m[30mThu Dec 10 06:08:30 PM EST 2020 assertError Failed[0m
-[0m[44m[30mThu Dec 10 06:08:31 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:08:35 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:39:42 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 07:39:44 PM EST 2020 assertNoError Passed[0m
+[0m[43m[30mThu Dec 10 07:39:51 PM EST 2020 assertError Failed[0m
+[0m[44m[30mThu Dec 10 07:39:52 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:39:56 PM EST 2020 testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:08:44 PM EST 2020 assertError Passed[0m
-[0m[104m[30mThu Dec 10 06:08:48 PM EST 2020 testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:40:07 PM EST 2020 assertError Passed[0m
+[0m[104m[30mThu Dec 10 07:40:11 PM EST 2020 testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:08:55 PM EST 2020 assertError Failed[0m
-[0m[43m[30mThu Dec 10 06:08:59 PM EST 2020 assertError Failed[0m
-[0m[43m[30mThu Dec 10 06:09:03 PM EST 2020 assertError Failed[0m
-[0m[104m[30mThu Dec 10 06:09:07 PM EST 2020 testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:40:19 PM EST 2020 assertError Failed[0m
+[0m[43m[30mThu Dec 10 07:40:24 PM EST 2020 assertError Failed[0m
+[0m[43m[30mThu Dec 10 07:40:29 PM EST 2020 assertError Failed[0m
+[0m[104m[30mThu Dec 10 07:40:33 PM EST 2020 testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:09:21 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
-[0m[44m[30mThu Dec 10 06:09:22 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:09:26 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:40:48 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
+[0m[44m[30mThu Dec 10 07:40:49 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:40:54 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:09:41 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
-[0m[44m[30mThu Dec 10 06:09:42 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:09:47 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:41:09 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
+[0m[44m[30mThu Dec 10 07:41:10 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:41:15 PM EST 2020 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:09:57 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
-[0m[104m[30mThu Dec 10 06:10:02 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:41:27 PM EST 2020 assertErrorIfDirectoryExists Passed[0m
+[0m[104m[30mThu Dec 10 07:41:31 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:10:10 PM EST 2020 assertErrorIfDirectoryExists Failed[0m
-[0m[104m[30mThu Dec 10 06:10:14 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:41:39 PM EST 2020 assertErrorIfDirectoryExists Failed[0m
+[0m[104m[30mThu Dec 10 07:41:44 PM EST 2020 testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:10:28 PM EST 2020 assertErrorIfFileExists Passed[0m
-[0m[44m[30mThu Dec 10 06:10:29 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:10:34 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:41:59 PM EST 2020 assertErrorIfFileExists Passed[0m
+[0m[44m[30mThu Dec 10 07:42:00 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:42:05 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:10:48 PM EST 2020 assertErrorIfFileExists Passed[0m
-[0m[44m[30mThu Dec 10 06:10:49 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:10:54 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:42:20 PM EST 2020 assertErrorIfFileExists Passed[0m
+[0m[44m[30mThu Dec 10 07:42:21 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:42:26 PM EST 2020 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:11:05 PM EST 2020 assertErrorIfFileExists Passed[0m
-[0m[104m[30mThu Dec 10 06:11:09 PM EST 2020 testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:42:37 PM EST 2020 assertErrorIfFileExists Passed[0m
+[0m[104m[30mThu Dec 10 07:42:41 PM EST 2020 testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:11:16 PM EST 2020 assertErrorIfFileExists Failed[0m
-[0m[104m[30mThu Dec 10 06:11:21 PM EST 2020 testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:42:49 PM EST 2020 assertErrorIfFileExists Failed[0m
+[0m[104m[30mThu Dec 10 07:42:54 PM EST 2020 testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:11:34 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:11:35 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:11:40 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:43:08 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:43:09 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:43:14 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:11:53 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:11:54 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:11:59 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:43:29 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:43:30 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:43:35 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:12:09 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 06:12:14 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:43:46 PM EST 2020 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 07:43:51 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:12:22 PM EST 2020 assertErrorIfDirectoryDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 06:12:26 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:43:59 PM EST 2020 assertErrorIfDirectoryDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 07:44:04 PM EST 2020 testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:12:39 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:12:40 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:12:45 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:44:18 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:44:19 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:44:24 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:12:58 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:12:59 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:13:04 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:44:39 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:44:40 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:44:44 PM EST 2020 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:13:13 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 06:13:18 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:44:55 PM EST 2020 assertErrorIfFileDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 07:45:00 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:13:25 PM EST 2020 assertErrorIfFileDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 06:13:30 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:45:08 PM EST 2020 assertErrorIfFileDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 07:45:12 PM EST 2020 testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:13:43 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[44m[30mThu Dec 10 06:13:44 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:13:48 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:45:27 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[44m[30mThu Dec 10 07:45:28 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:45:33 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:14:01 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[44m[30mThu Dec 10 06:14:03 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:14:07 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:45:47 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[44m[30mThu Dec 10 07:45:48 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:45:53 PM EST 2020 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:14:17 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[104m[30mThu Dec 10 06:14:22 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:46:03 PM EST 2020 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[104m[30mThu Dec 10 07:46:08 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:14:29 PM EST 2020 assertErrorIfFileIsNotExecutable Failed[0m
-[0m[104m[30mThu Dec 10 06:14:34 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:46:16 PM EST 2020 assertErrorIfFileIsNotExecutable Failed[0m
+[0m[104m[30mThu Dec 10 07:46:21 PM EST 2020 testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:14:46 PM EST 2020 assertDirectoryExists Failed[0m
-[0m[44m[30mThu Dec 10 06:14:47 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:14:52 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:46:35 PM EST 2020 assertDirectoryExists Failed[0m
+[0m[44m[30mThu Dec 10 07:46:36 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:46:40 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 06:15:06 PM EST 2020 assertDirectoryExists Failed[0m
-[0m[44m[30mThu Dec 10 06:15:07 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:15:11 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:46:56 PM EST 2020 assertDirectoryExists Failed[0m
+[0m[44m[30mThu Dec 10 07:46:57 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:47:01 PM EST 2020 testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:15:18 PM EST 2020 assertDirectoryExists Passed[0m
-[0m[104m[30mThu Dec 10 06:15:23 PM EST 2020 testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:47:09 PM EST 2020 assertDirectoryExists Passed[0m
+[0m[104m[30mThu Dec 10 07:47:13 PM EST 2020 testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:15:32 PM EST 2020 assertDirectoryExists Failed[0m
-[0m[104m[30mThu Dec 10 06:15:36 PM EST 2020 testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:47:24 PM EST 2020 assertDirectoryExists Failed[0m
+[0m[104m[30mThu Dec 10 07:47:28 PM EST 2020 testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:15:51 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:15:52 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:15:56 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:47:43 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:47:44 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:47:49 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:16:09 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:16:10 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:16:15 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:48:03 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:48:04 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:48:09 PM EST 2020 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:16:24 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 06:16:29 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:48:19 PM EST 2020 assertDirectoryDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 07:48:24 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:16:37 PM EST 2020 assertDirectoryDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 06:16:41 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:48:32 PM EST 2020 assertDirectoryDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 07:48:36 PM EST 2020 testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:16:53 PM EST 2020 assertFileExists Failed[0m
-[0m[44m[30mThu Dec 10 06:16:54 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:16:59 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:48:50 PM EST 2020 assertFileExists Failed[0m
+[0m[44m[30mThu Dec 10 07:48:51 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:48:55 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[43m[30mThu Dec 10 06:17:13 PM EST 2020 assertFileExists Failed[0m
-[0m[44m[30mThu Dec 10 06:17:14 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:17:18 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:49:11 PM EST 2020 assertFileExists Failed[0m
+[0m[44m[30mThu Dec 10 07:49:12 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:49:16 PM EST 2020 testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:17:25 PM EST 2020 assertFileExists Passed[0m
-[0m[104m[30mThu Dec 10 06:17:29 PM EST 2020 testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:49:23 PM EST 2020 assertFileExists Passed[0m
+[0m[104m[30mThu Dec 10 07:49:27 PM EST 2020 testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:17:38 PM EST 2020 assertFileExists Failed[0m
-[0m[104m[30mThu Dec 10 06:17:42 PM EST 2020 testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:49:38 PM EST 2020 assertFileExists Failed[0m
+[0m[104m[30mThu Dec 10 07:49:42 PM EST 2020 testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[44m[30mThu Dec 10 06:17:57 PM EST 2020 assertFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:17:58 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:18:02 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:49:57 PM EST 2020 assertFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:49:58 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:50:02 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:18:15 PM EST 2020 assertFileDoesNotExist Passed[0m
-[0m[44m[30mThu Dec 10 06:18:16 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:18:20 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:50:16 PM EST 2020 assertFileDoesNotExist Passed[0m
+[0m[44m[30mThu Dec 10 07:50:18 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:50:22 PM EST 2020 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:18:30 PM EST 2020 assertFileDoesNotExist Passed[0m
-[0m[104m[30mThu Dec 10 06:18:34 PM EST 2020 testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:50:32 PM EST 2020 assertFileDoesNotExist Passed[0m
+[0m[104m[30mThu Dec 10 07:50:37 PM EST 2020 testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:18:41 PM EST 2020 assertFileDoesNotExist Failed[0m
-[0m[104m[30mThu Dec 10 06:18:46 PM EST 2020 testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:50:45 PM EST 2020 assertFileDoesNotExist Failed[0m
+[0m[104m[30mThu Dec 10 07:50:49 PM EST 2020 testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:18:54 PM EST 2020 assertEquals Failed[0m
-[0m[44m[30mThu Dec 10 06:18:55 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:18:59 PM EST 2020 testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:50:59 PM EST 2020 assertEquals Failed[0m
+[0m[44m[30mThu Dec 10 07:51:00 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:51:04 PM EST 2020 testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:19:07 PM EST 2020 assertEquals Passed[0m
-[0m[44m[30mThu Dec 10 06:19:08 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:19:12 PM EST 2020 testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:51:14 PM EST 2020 assertEquals Passed[0m
+[0m[44m[30mThu Dec 10 07:51:15 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:51:19 PM EST 2020 testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:19:18 PM EST 2020 assertEquals Passed[0m
-[0m[104m[30mThu Dec 10 06:19:22 PM EST 2020 testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:51:27 PM EST 2020 assertEquals Passed[0m
+[0m[104m[30mThu Dec 10 07:51:31 PM EST 2020 testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:19:29 PM EST 2020 assertEquals Failed[0m
-[0m[104m[30mThu Dec 10 06:19:33 PM EST 2020 testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:51:38 PM EST 2020 assertEquals Failed[0m
+[0m[104m[30mThu Dec 10 07:51:42 PM EST 2020 testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:19:41 PM EST 2020 assertNotEquals Failed[0m
-[0m[44m[30mThu Dec 10 06:19:42 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:19:46 PM EST 2020 testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+[0m[43m[30mThu Dec 10 07:51:52 PM EST 2020 assertNotEquals Failed[0m
+[0m[44m[30mThu Dec 10 07:51:53 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:51:58 PM EST 2020 testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:19:54 PM EST 2020 assertNotEquals Passed[0m
-[0m[44m[30mThu Dec 10 06:19:55 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mThu Dec 10 06:20:00 PM EST 2020 testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+[0m[44m[30mThu Dec 10 07:52:08 PM EST 2020 assertNotEquals Passed[0m
+[0m[44m[30mThu Dec 10 07:52:09 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mThu Dec 10 07:52:13 PM EST 2020 testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
 
-[0m[44m[30mThu Dec 10 06:20:06 PM EST 2020 assertNotEquals Passed[0m
-[0m[104m[30mThu Dec 10 06:20:10 PM EST 2020 testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+[0m[44m[30mThu Dec 10 07:52:21 PM EST 2020 assertNotEquals Passed[0m
+[0m[104m[30mThu Dec 10 07:52:25 PM EST 2020 testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
 
-[0m[43m[30mThu Dec 10 06:20:16 PM EST 2020 assertNotEquals Failed[0m
-[0m[104m[30mThu Dec 10 06:20:20 PM EST 2020 testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+[0m[43m[30mThu Dec 10 07:52:32 PM EST 2020 assertNotEquals Failed[0m
+[0m[104m[30mThu Dec 10 07:52:36 PM EST 2020 testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m


### PR DESCRIPTION
dshUnit: Implemented `dshUnitAssertions::assertEquals()` and `dshUnitAssertions.sh::assertNotEquals()`.

Implemented the following tests for `dshUnitAssertions.sh::assertEquals()`:

```
testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected
testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected
testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion
testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion
```

Implemented the following tests for `dshUnitAssertions.sh::assertNotEquals()`:

```
testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected
testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected
testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion
testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion
```

All dshUnit tests are passing.

This commit is related to issue #26.
