### PR TITLE
Dsh

### DIFF
--- a/dsh/Tests/helpFLAGTests.sh
+++ b/dsh/Tests/helpFLAGTests.sh
@@ -3,6 +3,16 @@
 
 set -o posix
 
+determineHelpFilesDirectoryPath() {
+   printf "%s" "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles"
+}
+
+expectedHelpFileOutput() {
+    local text
+    text="$(dshUI -c "$(determineHelpFilesDirectoryPath)/${1}" 33 "dsh -.*[>]" "[<].*[>]" "dshUnit ")"
+    printf "%s" "${text}"
+}
+
 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid() {
     assertError "dsh --help foo" "dsh --help <FLAG> must log an error if an invalid flag is specified."
     assertError "dsh --help --foo" "dsh --help <FLAG> must log an error if an invalid flag is specified."
@@ -44,81 +54,81 @@ testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid() {
     assertNoError "dsh -h -d" "dsh -h -d MUST run without error."
 }
 
-testDshHelpHelpOutputMatchesHelpTxtHelpFileContent() {
-    assertEquals "$(dsh --help --help)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/help.txt")" "dsh --help --help output MUST match help.txt help file content."
+testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent() {
+    assertEquals "$(dsh --help --help)" "$(expectedHelpFileOutput help.txt)" "dsh --help --help MUST match help.txt help file content."
 }
 
-testDshHelpFLAGOutputMatchesHelpFLAGHelpFileContent() {
-    assertEquals "$(dsh --help FLAG)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/helpFLAG.txt")" "dsh --help FLAG output MUST match helpFLAG.txt help file content."
+testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent() {
+    assertEquals "$(dsh --help FLAG)" "$(expectedHelpFileOutput helpFLAG.txt)" "dsh --help FLAG MUST match helpFLAG.txt help file content."
 }
 
-testDshHelpFlagsOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help flags)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/helpFlags.txt")" "dsh --help flags output MUST match helpFlags.txt help file content."
+testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput() {
+    assertEquals "$(dsh --help flags)" "$(expectedHelpFileOutput helpFlags.txt)" "dsh --help flags MUST match helpFlags.txt help file content."
 }
 
-testDshHelpStartDevelopmentServerOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --start-development-server)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/startDevelopmentServer.txt")" "dsh --help --start-development-server output MUST match startDevelopmentServer.txt help file content."
+testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput() {
+    assertEquals "$(dsh --help --start-development-server)" "$(expectedHelpFileOutput startDevelopmentServer.txt)" "dsh --help --start-development-server MUST match startDevelopmentServer.txt help file content."
 }
 
-testDshHelpBuildAppOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --build-app)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/buildApp.txt")" "dsh --help --build-app output MUST match buildApp.txt help file content."
+testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput() {
+    assertEquals "$(dsh --help --build-app)" "$(expectedHelpFileOutput buildApp.txt)" "dsh --help --build-app MUST match buildApp.txt help file content."
 }
 
-testDshHelpNewOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/new.txt")" "dsh --help --new output MUST match new.txt help file content."
+testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput() {
+    assertEquals "$(dsh --help --new)" "$(expectedHelpFileOutput new.txt)" "dsh --help --new MUST match new.txt help file content."
 }
 
-testDshHelpNewAppOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new App)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/newApp.txt")" "dsh --help --new App output MUST match newApp.txt help file content."
+testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput() {
+    assertEquals "$(dsh --help --new App)" "$(expectedHelpFileOutput newApp.txt)" "dsh --help --new App MUST match newApp.txt help file content."
 }
 
-testDshHelpNewOutputComponentOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new OutputComponent)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/newOutputComponent.txt")" "dsh --help --new OutputComponent output MUST match newOutputComponent.txt help file content."
+testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput() {
+    assertEquals "$(dsh --help --new OutputComponent)" "$(expectedHelpFileOutput newOutputComponent.txt)" "dsh --help --new OutputComponent MUST match newOutputComponent.txt help file content."
 }
 
-testDshHelpNewDynamicOutputComponentOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new DynamicOutputComponent)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/newDynamicOutputComponent.txt")" "dsh --help --new DynamicOutputComponent output MUST match newDynamicOutputComponent.txt help file content."
+testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput() {
+    assertEquals "$(dsh --help --new DynamicOutputComponent)" "$(expectedHelpFileOutput newDynamicOutputComponent.txt)" "dsh --help --new DynamicOutputComponent MUST match newDynamicOutputComponent.txt help file content."
 }
 
-testDshHelpNewRequestOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new Request)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/newRequest.txt")" "dsh --help --new Request output MUST match newRequest.txt help file content."
+testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput() {
+    assertEquals "$(dsh --help --new Request)" "$(expectedHelpFileOutput newRequest.txt)" "dsh --help --new Request MUST match newRequest.txt help file content."
 }
 
-testDshHelpNewResponseOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new Response)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/newResponse.txt")" "dsh --help --new Response output MUST match newResponse.txt help file content."
+testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput() {
+    assertEquals "$(dsh --help --new Response)" "$(expectedHelpFileOutput newResponse.txt)" "dsh --help --new Response MUST match newResponse.txt help file content."
 }
 
-testDshHelpNewGlobalResponseOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --new GlobalResponse)" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/newGlobalResponse.txt")" "dsh --help --new GlobalResponse output MUST match newGlobalResponse.txt help file content."
+testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput() {
+    assertEquals "$(dsh --help --new GlobalResponse)" "$(expectedHelpFileOutput newGlobalResponse.txt)" "dsh --help --new GlobalResponse MUST match newGlobalResponse.txt help file content."
 }
 
-testDshHelpAssignToResponseOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --assign-to-response )" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/assignToResponse.txt")" "dsh --help --assign-to-response output MUST match assignToResponse.txt help file content."
+testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput() {
+    assertEquals "$(dsh --help --assign-to-response)" "$(expectedHelpFileOutput assignToResponse.txt)" "dsh --help --assign-to-response output MUST match assignToResponse.txt help file content."
 }
 
-testDshHelpPhpUnitOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --php-unit )" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/phpUnit.txt")" "dsh --help --php-unit output MUST match phpUnit.txt help file content."
+testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput() {
+    assertEquals "$(dsh --help --php-unit )" "$(expectedHelpFileOutput phpUnit.txt)" "dsh --help --php-unit output MUST match phpUnit.txt help file content."
 }
 
-testDshHelpDshUnitOutputMatchesHelpFlagsHelpFileContent() {
-    assertEquals "$(dsh --help --dsh-unit )" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/helpFiles/dshUnit.txt")" "dsh --help --dsh-unit output MUST match dshUnit.txt help file content."
+testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput() {
+    assertEquals "$(dsh --help --dsh-unit )" "$(expectedHelpFileOutput dshUnit.txt)" "dsh --help --dsh-unit output MUST match dshUnit.txt help file content."
 }
 
 runTest testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid 3
 runTest testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid 30
-runTest testDshHelpHelpOutputMatchesHelpTxtHelpFileContent
-runTest testDshHelpFLAGOutputMatchesHelpFLAGHelpFileContent
-runTest testDshHelpFlagsOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpStartDevelopmentServerOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpBuildAppOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewAppOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewOutputComponentOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewDynamicOutputComponentOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewRequestOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewResponseOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpNewGlobalResponseOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpAssignToResponseOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpPhpUnitOutputMatchesHelpFlagsHelpFileContent
-runTest testDshHelpDshUnitOutputMatchesHelpFlagsHelpFileContent
+runTest testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent
+runTest testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent
+runTest testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput
+runTest testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput
+runTest testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput
+runTest testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput
+runTest testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput
+runTest testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput
+runTest testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput
+runTest testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput
+runTest testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput
+runTest testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput
+runTest testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput
+runTest testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput
+runTest testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput
 

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -43,7 +43,9 @@ updateAndShowManPage() {
 }
 
 showHelpFile() {
-    cat "$(determineDshDirectoryPath)/helpFiles/${1}"
+    local text
+    text="$(dshUI -c "$(determineDshDirectoryPath)/helpFiles/${1}" 33 "dsh -.*[>]" "[<].*[>]" "dshUnit ")"
+    printf "%s" "${text}"
     exit 0
 }
 

--- a/dshUI/colorize.sh
+++ b/dshUI/colorize.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# colorizeHelpFile.sh
-# colorizeHelpFile <FILE_NAME> <COLOR_CODE> <REGEX>
+# colorize <FILE_PATH_OR_STRING> <COLOR_CODE> <REGEX>...
 
 set -o posix
 
@@ -8,18 +7,17 @@ setTextStyleCode() {
   printf "\e[%sm" "${1}"
 }
 
-[[ -z "${1}" ]] && printf "\n\e[033mArgument 1 must specify the name of a help file.\e[0m\n" && exit 1
-[[ -z "${3}" ]] && printf "\n\e[033mAt least one regular expression must be specified.\e[0m\n" && exit 1
+[[ -z "${1}" ]] && printf "\n\e[033mdshUI <FILE_PATH_OR_STRING> <COLOR_CODE> <REGEX>... You must specify a valid file path or string\e[0m\n" && exit 1
+[[ -z "${2}" ]] && printf "\n\e[033mdshUI <FILE_PATH_OR_STRING> <COLOR_CODE> <REGEX>... You must specify a color code\e[0m\n" && exit 1
 
-dsh_helpFiles_directory_path="${HOME}/Downloads/DarlingDataManagementSystem/dsh/helpFiles"
-help_file_path="${1}"
+file_path_or_string="${1}"
 color_code="${2}"
 clear_color="$(setTextStyleCode 0)"
 
-[[ ! -f "${help_file_path}" ]] && printf "\n\e[033mError:\n${help_file_path} does not exist.\nYou must specify the name of an existing help file.\nThe following files are available:\e[0m\n" && ls && exit 1
 colorize() {
     local text color_code
-    text="$(cat "${1}")"
+    [[ -f "${file_path_or_string}" ]] && text="$(cat "${1}")"
+    text="${text:-${1}}"
     color_code="${2}"
     for var in "$@"
     do
@@ -30,4 +28,4 @@ colorize() {
     printf "%s" "${text}"
 }
 
-colorize "${help_file_path}" "${color_code}" "$@"
+colorize "${file_path_or_string}" "${color_code}" "$@"

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,112 +1,112 @@
 
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpRunsWithoutError     =-=-[0m
-[0m[44m[30mFri Dec 18 11:50:43 AM EST 2020 assertNoError Passed[0m
-[0m[104m[30mFri Dec 18 11:50:45 AM EST 2020 testDshHelpRunsWithoutError Passed[0m
+[0m[44m[30mSun Dec 20 11:51:09 AM EST 2020 assertNoError Passed[0m
+[0m[104m[30mSun Dec 20 11:51:11 AM EST 2020 testDshHelpRunsWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpCreatesSystemManPageForDsh     =-=-[0m
-[0m[44m[30mFri Dec 18 11:50:53 AM EST 2020 assertFileExists Passed[0m
-[0m[104m[30mFri Dec 18 11:50:56 AM EST 2020 testDshHelpCreatesSystemManPageForDsh Passed[0m
+[0m[44m[30mSun Dec 20 11:51:18 AM EST 2020 assertFileExists Passed[0m
+[0m[104m[30mSun Dec 20 11:51:20 AM EST 2020 testDshHelpCreatesSystemManPageForDsh Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpOutputMatchesManDshOutput     =-=-[0m
-[0m[44m[30mFri Dec 18 11:51:02 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:51:05 AM EST 2020 testDshHelpOutputMatchesManDshOutput Passed[0m
+[0m[44m[30mSun Dec 20 11:51:27 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:51:30 AM EST 2020 testDshHelpOutputMatchesManDshOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid     =-=-[0m
-[0m[44m[30mFri Dec 18 11:51:15 AM EST 2020 assertError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:22 AM EST 2020 assertError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:29 AM EST 2020 assertError Passed[0m
-[0m[104m[30mFri Dec 18 11:51:33 AM EST 2020 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
+[0m[44m[30mSun Dec 20 11:51:38 AM EST 2020 assertError Passed[0m
+[0m[44m[30mSun Dec 20 11:51:45 AM EST 2020 assertError Passed[0m
+[0m[44m[30mSun Dec 20 11:51:51 AM EST 2020 assertError Passed[0m
+[0m[104m[30mSun Dec 20 11:51:55 AM EST 2020 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid     =-=-[0m
-[0m[44m[30mFri Dec 18 11:51:39 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:42 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:46 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:50 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:54 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:51:58 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:02 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:06 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:10 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:14 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:19 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:23 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:27 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:31 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:35 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:38 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:42 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:46 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:50 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:54 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:52:57 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:01 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:05 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:09 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:13 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:17 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:21 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:25 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:29 AM EST 2020 assertNoError Passed[0m
-[0m[44m[30mFri Dec 18 11:53:33 AM EST 2020 assertNoError Passed[0m
-[0m[104m[30mFri Dec 18 11:53:36 AM EST 2020 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
+[0m[44m[30mSun Dec 20 11:52:00 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:03 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:06 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:09 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:13 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:16 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:19 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:22 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:25 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:29 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:32 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:35 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:38 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:41 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:44 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:47 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:50 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:53 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:56 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:52:59 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:02 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:05 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:08 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:12 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:15 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:18 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:21 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:24 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:27 AM EST 2020 assertNoError Passed[0m
+[0m[44m[30mSun Dec 20 11:53:30 AM EST 2020 assertNoError Passed[0m
+[0m[104m[30mSun Dec 20 11:53:33 AM EST 2020 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpHelpOutputMatchesHelpTxtHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:53:42 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:53:46 AM EST 2020 testDshHelpHelpOutputMatchesHelpTxtHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent     =-=-[0m
+[0m[44m[30mSun Dec 20 11:53:39 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:53:43 AM EST 2020 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGOutputMatchesHelpFLAGHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:53:52 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:53:56 AM EST 2020 testDshHelpFLAGOutputMatchesHelpFLAGHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent     =-=-[0m
+[0m[44m[30mSun Dec 20 11:53:49 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:53:53 AM EST 2020 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFlagsOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:54:02 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:54:05 AM EST 2020 testDshHelpFlagsOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:53:59 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:54:03 AM EST 2020 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpStartDevelopmentServerOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:54:13 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:54:17 AM EST 2020 testDshHelpStartDevelopmentServerOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:54:11 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:54:16 AM EST 2020 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpBuildAppOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:54:25 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:54:29 AM EST 2020 testDshHelpBuildAppOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:54:25 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:54:29 AM EST 2020 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:54:39 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:54:42 AM EST 2020 testDshHelpNewOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:54:39 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:54:43 AM EST 2020 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:55:05 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:55:09 AM EST 2020 testDshHelpNewAppOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:55:07 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:55:11 AM EST 2020 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputComponentOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:55:21 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:55:25 AM EST 2020 testDshHelpNewOutputComponentOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:55:24 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:55:28 AM EST 2020 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewDynamicOutputComponentOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:55:39 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:55:43 AM EST 2020 testDshHelpNewDynamicOutputComponentOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:55:43 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:55:48 AM EST 2020 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewRequestOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:55:54 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:55:58 AM EST 2020 testDshHelpNewRequestOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:56:01 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:56:05 AM EST 2020 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewResponseOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:56:23 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:56:27 AM EST 2020 testDshHelpNewResponseOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:56:31 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:56:35 AM EST 2020 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewGlobalResponseOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:56:47 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:56:50 AM EST 2020 testDshHelpNewGlobalResponseOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:56:55 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:56:59 AM EST 2020 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpAssignToResponseOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:57:08 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:57:12 AM EST 2020 testDshHelpAssignToResponseOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:57:18 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:57:22 AM EST 2020 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpPhpUnitOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:57:19 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:57:22 AM EST 2020 testDshHelpPhpUnitOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:57:29 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:57:33 AM EST 2020 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpDshUnitOutputMatchesHelpFlagsHelpFileContent     =-=-[0m
-[0m[44m[30mFri Dec 18 11:57:30 AM EST 2020 assertEquals Passed[0m
-[0m[104m[30mFri Dec 18 11:57:34 AM EST 2020 testDshHelpDshUnitOutputMatchesHelpFlagsHelpFileContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput     =-=-[0m
+[0m[44m[30mSun Dec 20 11:57:42 AM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 20 11:57:45 AM EST 2020 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m


### PR DESCRIPTION
DSH: Continued development of **dsh**. Code clean up. Refactored tests defined in `dsh/Tests/helpFLAGTests.sh`:

The following tests replace the test that formerly tested that uses of
`dsh --help <ARGUMENTS>...` output the contents of the relevant help file
to instead test the uses of `dsh --help <ARGUMENTS>...` output the contents
of the relevant help file "colorized" by `dshUI --colorize`.

```
testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent() 
testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent() 
testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput() 
testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput() 
testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput() 
testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput() 
testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput() 
testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput() 
testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput() 
testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput() 
testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput() 
testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput() 
testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput() 
testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput() 
testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput() 
```

The expected output is defined by the `helpFLAGTests.sh::expectedHelpFileOutput()`
function. Any future expectations for the ouput of `dsh --help <ARGUMENTS>...` MUST
be defined in the `helpFLAGTests.sh::expectedHelpFileOutput()`
function.

`dsh --help <ARGUMENTS>...` is working, help output is defined in appropriate plain
text files located at `dsh/helpFiles/<HELP_FILE_NAME>.txt`, and is displayed with
color via internal calls to `dshUI --colorize | -c "${HELP_FILE_PATH}" "${COLOR_CODE}" "${REGEX}"...`


All **dsh** tests are passing.

This commit is related to issue #27.


