### PR TITLE
Dsh

### DIFF
--- a/dsh/AppWasBuilt.php
+++ b/dsh/AppWasBuilt.php
@@ -1,0 +1,33 @@
+<?php
+
+use DarlingDataManagementSystem\classes\component\Factory\App\AppComponentsFactory;
+use DarlingDataManagementSystem\classes\component\Web\App;
+
+ini_set('display_errors', true);
+
+require(
+    '..' .
+    DIRECTORY_SEPARATOR .
+    '..' .
+    DIRECTORY_SEPARATOR .
+    'vendor' .
+    DIRECTORY_SEPARATOR .
+    'autoload.php'
+);
+
+$appComponentsFactory = new AppComponentsFactory(
+    ...AppComponentsFactory::buildConstructorArgs(
+    AppComponentsFactory::buildDomain('http://testdomain.dev')
+    )
+);
+
+$opts = getopt('a:');
+$appName = $opts['a'];
+$app = $appComponentsFactory->getComponentCrud()->readByNameAndType(
+    $appName,
+    App::class,
+    $appName,
+    App::APP_CONTAINER
+);
+
+echo '\n\e[102m\e[30mApp name: ' . $appName;

--- a/dsh/Tests/buildAppTests.sh
+++ b/dsh/Tests/buildAppTests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# buildAppTests.sh
+
+set -o posix
+
+testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified() {
+    assertError "dsh --build-app" "dsh --build-app <APP_NAME> <DOMAIN> MUST run with an error if <APP_NAME> is not specified."
+}
+
+runTest testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified

--- a/dsh/Tests/buildAppTests.sh
+++ b/dsh/Tests/buildAppTests.sh
@@ -3,8 +3,42 @@
 
 set -o posix
 
-testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified() {
+determineDDMSDirectoryPath() {
+    printf "%s" "$(determineDshUnitDirectoryPath | sed 's/\/dshUnit//g')"
+}
+
+determineDcmsJsonDataDirectoryPath() {
+    printf "%s" "$(determineDDMSDirectoryPath)/.dcmsJsonData"
+}
+
+removeDcmsJsonDirectory() {
+    showLoadingBar "    Attempting to remove $(determineDcmsJsonDataDirectoryPath)" 'dontClear'
+    if [[ -d "$(determineDcmsJsonDataDirectoryPath)" ]]; then
+        rm -R "$(determineDcmsJsonDataDirectoryPath)"
+        [[ -d "$(determineDcmsJsonDataDirectoryPath)" ]] && notifyUser "    ${ERROR_COLOR}Failed to remove$(determineDDMSDirectoryPath).dcmsJsonData" 0 'dontClear'
+        [[ ! -d "$(determineDcmsJsonDataDirectoryPath)" ]] && notifyUser "    Removed $(determineDcmsJsonDataDirectoryPath)" 0 'dontClear'
+        return 0
+    fi
+    notifyUser "    ${ERROR_COLOR}Did not remove $(determineDcmsJsonDataDirectoryPath) because it does not exist." 0 'dontClear'
+}
+
+moveIntoStarterAppDirectory() {
+    # starterApp is used by test for now because it come packaged with the Darling Data Management System, this may change in the future.
+    cd "$(determineDDMSDirectoryPath)/Apps/starterApp/"
+}
+
+testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified() {
     assertError "dsh --build-app" "dsh --build-app <APP_NAME> <DOMAIN> MUST run with an error if <APP_NAME> is not specified."
 }
 
-runTest testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified
+testDshBuildAppBuildsSpecifiedApp() {
+    removeDcmsJsonDirectory
+    moveIntoStarterAppDirectory
+    dsh --build-app starterApp http://localhost:8080
+    assertNoError "/usr/bin/php -e $(determineDDMSDirectoryPath)/dsh/AppWasBuilt.php -a=localhost8080" "AppWasBuilt.php MUST run without error, if it does not then the App was not built."
+    removeDcmsJsonDirectory
+}
+
+runTest testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified
+# @todo Propmt before running this test since it will delete .dcmsJsonData
+runTest testDshBuildAppBuildsSpecifiedApp

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -108,6 +108,21 @@ startDevelopmentServer() {
     exit 0
 }
 
+determineAppDirectoryPath() {
+    printf "%s" "$(determineDshDirectoryPath | sed "s/dsh/Apps\/${1}/g")"
+}
+
+buildApp() {
+    [[ -z "${1}" ]] && logErrorMsgAndExit1 "dsh --build-app <APP_NAME> <DOMAIN> expects the name of the app be specified as the first parameter."
+    [[ ! -d "$(determineAppDirectoryPath "${1}")" ]] && logErrorMsgAndExit1 "dsh --build-app <APP_NAME> <DOMAIN> expects the name of the app be specified as the first parameter."
+    cd "$(determineAppDirectoryPath "${1}")"
+    /usr/bin/php ./Components.php
+    # Note to self: Remeber, an App's name is always the camel case alphanumeric form of the App's domain
+    # For example, an App built for the domain examplesite.com would be assigned the name "examplesite"
+    printf "\n    \e[103m\e[30m--build app is still in development\e[0m\n"
+    exit 0
+}
+
 loadLibrary "$(determineDshDirectoryPath | sed 's/\/dsh//g')/dshUI/dshUI" "--theme dsh.sh"
 
 while test $# -gt 0; do
@@ -122,7 +137,7 @@ while test $# -gt 0; do
     ;;
   -b | --build-app)
     shift
-    [[ -z "${1}" ]] && logErrorMsgAndExit1 "dsh --build-app <APP_NAME> <DOMAIN> expects the name of the app be specified as the first parameter."
+    buildApp "${1}" "${2}"
     ;;
   *)
     shift

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -120,6 +120,10 @@ while test $# -gt 0; do
     shift
     startDevelopmentServer "${1:-8080}"
     ;;
+  -b | --build-app)
+    shift
+    [[ -z "${1}" ]] && logErrorMsgAndExit1 "dsh --build-app <APP_NAME> <DOMAIN> expects the name of the app be specified as the first parameter."
+    ;;
   *)
     shift
     logErrorMsgAndExit1 "Invalid flag ${1}"

--- a/dsh/dshTestsConfig.sh
+++ b/dsh/dshTestsConfig.sh
@@ -15,4 +15,8 @@ if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'Test
     loadLibrary "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/Tests/startDevelopmentServerTests.sh"
 fi
 
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestDshBuildApp' ]]; then
+    loadLibrary "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/Tests/buildAppTests.sh"
+fi
+
 

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,5 +1,9 @@
 
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Dec 21 07:02:50 AM EST 2020 assertError Passed[0m
-[0m[104m[30mMon Dec 21 07:02:54 AM EST 2020 testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Dec 21 06:30:45 PM EST 2020 assertError Passed[0m
+[0m[104m[30mMon Dec 21 06:30:49 PM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Dec 21 06:31:06 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mMon Dec 21 06:31:12 PM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -7,3 +7,11 @@
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
 [0m[44m[30mMon Dec 21 06:31:06 PM EST 2020 assertNoError Passed[0m
 [0m[104m[30mMon Dec 21 06:31:12 PM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Dec 21 06:43:19 PM EST 2020 assertError Passed[0m
+[0m[104m[30mMon Dec 21 06:43:22 PM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Dec 21 06:43:39 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mMon Dec 21 06:43:45 PM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,14 +1,5 @@
 
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerStartsADevelopmentServerWithoutError     =-=-[0m
-[0m[44m[30mSun Dec 20 09:07:05 PM EST 2020 assertNoError Passed[0m
-[0m[44m[30mSun Dec 20 09:07:08 PM EST 2020 assertEquals Passed[0m
-[0m[104m[30mSun Dec 20 09:07:12 PM EST 2020 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified     =-=-[0m
-[0m[44m[30mSun Dec 20 09:07:19 PM EST 2020 assertEquals Passed[0m
-[0m[104m[30mSun Dec 20 09:07:23 PM EST 2020 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified     =-=-[0m
-[0m[44m[30mSun Dec 20 09:07:30 PM EST 2020 assertEquals Passed[0m
-[0m[104m[30mSun Dec 20 09:07:34 PM EST 2020 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Dec 21 07:02:50 AM EST 2020 assertError Passed[0m
+[0m[104m[30mMon Dec 21 07:02:54 AM EST 2020 testDhBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m


### PR DESCRIPTION
DSH: Continued development of **dsh**.

Implemented the following tests for `dsh --build-app <APP_NAME> <DOMAIN>` in `dsh/Tests/buildAppTests.sh`:
```
    testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified()
    testDshBuildAppBuildsSpecifiedApp()
```

```
Note: Implemented dsh/AppWasBuilt.php which will attempt to read the
specified app from storage, if the app does not exist, AppWasBuilt.php
will throw an error. testDshBuildAppBuildsSpecifiedApp uses
AppWasBuilt.php to determine if the specified App was in fact built.
AppWasBuilt.php allows testDshBuildAppBuildsSpecifiedApp to verify that the
specified App exists in storage after dsh --build app <APP_NAME>
<DOMAIN> is run.
```

Ran `dshUnit -c dsh/dshTestsConfig.sh -t TestDshBuildApp`

Ran `dsh --build-app starterApp` manually, manual test passed.

All defined `dsh --build-app` tests are passing.

This merge is related to issue #27.

