### PR TITLE
DSH: Continued development of dsh --start-development-server. Code cl…

### DIFF
--- a/dsh/Tests/buildAppTests.sh
+++ b/dsh/Tests/buildAppTests.sh
@@ -40,5 +40,15 @@ testDshBuildAppBuildsSpecifiedApp() {
 }
 
 runTest testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified
-# @todo Propmt before running this test since it will delete .dcmsJsonData
-runTest testDshBuildAppBuildsSpecifiedApp
+
+notifyUser "    ${ERROR_COLOR}Warning: testDshBuildAppBuildsSpecifiedApp will delete the $(determineDcmsJsonDataDirectoryPath) directory?" 0 'dontClear'
+notifyUser "    ${ERROR_COLOR} DO NOT RUN THIS TEST IF IT IS NOT OKAY TO REMOVE $(determineDcmsJsonDataDirectoryPath)" 0 'dontClear'
+notifyUser "    ${HIGHLIGHTCOLOR}Please enter \"1\" to run the test and allow dsh to delete the $(determineDcmsJsonDataDirectoryPath)" 0 'dontClear'
+notifyUser "    ${HIGHLIGHTCOLOR}Please enter \"2\", to skip the test, in which case the $(determineDcmsJsonDataDirectoryPath) directory will not be deleted: " 0 'dontClear'
+select rs in "Run" "Skip"; do
+    case $rs in
+        Run ) runTest testDshBuildAppBuildsSpecifiedApp; break;;
+        Skip ) notifyUser "Skipping testDshBuildAppBuildsSpecifiedApp" 0 'dontClear'; break;;
+    esac
+done
+

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,17 +1,49 @@
 
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Dec 21 06:30:45 PM EST 2020 assertError Passed[0m
-[0m[104m[30mMon Dec 21 06:30:49 PM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Dec 21 06:31:06 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mMon Dec 21 06:31:12 PM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+[0m[44m[30mTue Dec 22 02:30:44 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:30:47 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Dec 21 06:43:19 PM EST 2020 assertError Passed[0m
-[0m[104m[30mMon Dec 21 06:43:22 PM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mTue Dec 22 02:31:26 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:31:29 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Dec 21 06:43:39 PM EST 2020 assertNoError Passed[0m
-[0m[104m[30mMon Dec 21 06:43:45 PM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+[0m[44m[30mTue Dec 22 02:32:06 AM EST 2020 assertNoError Passed[0m
+[0m[104m[30mTue Dec 22 02:32:11 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mTue Dec 22 02:34:00 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:34:03 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mTue Dec 22 02:35:52 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:35:55 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mTue Dec 22 02:36:40 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:36:43 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mTue Dec 22 02:37:43 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:37:46 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
+[0m[44m[30mTue Dec 22 02:38:18 AM EST 2020 assertNoError Passed[0m
+[0m[104m[30mTue Dec 22 02:38:23 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mTue Dec 22 02:39:04 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:39:07 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
+[0m[44m[30mTue Dec 22 02:39:39 AM EST 2020 assertNoError Passed[0m
+[0m[104m[30mTue Dec 22 02:39:45 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mTue Dec 22 02:40:20 AM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 02:40:23 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
+[0m[44m[30mTue Dec 22 02:40:53 AM EST 2020 assertNoError Passed[0m
+[0m[104m[30mTue Dec 22 02:40:58 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m


### PR DESCRIPTION
DSH: Continued development of `dsh --start-development-server`. Code clean up. Refactored `dsh/Tests/buildAppTests.sh` to prompt user before running the `testDshBuildAppBuildsSpecifiedApp()` test since the `testDshBuildAppBuildsSpecifiedApp()` test removes the `.dcmsJsonData` directory, which may not always be desired. All `dsh --build-app` tests are passing. This commit is related to issue #27.