### PR TITLE
DSH: Continued development of dsh --build-app. 

### DIFF
--- a/dsh/Tests/buildAppTests.sh
+++ b/dsh/Tests/buildAppTests.sh
@@ -31,6 +31,10 @@ testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified() {
     assertError "dsh --build-app" "dsh --build-app <APP_NAME> <DOMAIN> MUST run with an error if <APP_NAME> is not specified."
 }
 
+testDshBuildAppRunsWithErrorIfSpecifiedAppDoesNotExist() {
+    assertError "dsh --build-app FooBar${RANDOM}" "dsh --build-app <APP_NAME> <DOMAIN> MUST run with an error if specified App does not exist."
+}
+
 testDshBuildAppBuildsSpecifiedApp() {
     removeDcmsJsonDirectory
     moveIntoStarterAppDirectory
@@ -40,6 +44,7 @@ testDshBuildAppBuildsSpecifiedApp() {
 }
 
 runTest testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified
+runTest testDshBuildAppRunsWithErrorIfSpecifiedAppDoesNotExist
 
 notifyUser "    ${ERROR_COLOR}Warning: testDshBuildAppBuildsSpecifiedApp will delete the $(determineDcmsJsonDataDirectoryPath) directory?" 0 'dontClear'
 notifyUser "    ${ERROR_COLOR} DO NOT RUN THIS TEST IF IT IS NOT OKAY TO REMOVE $(determineDcmsJsonDataDirectoryPath)" 0 'dontClear'

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -104,7 +104,7 @@ showHelpInfo() {
 
 startDevelopmentServer() {
     showLoadingBar "    Starting development server at http://localhost:${1:-8080}" 'dontClear'
-    /usr/bin/php -S "localhost:${1:-8080}" -t "${HOME}/Downloads/DarlingDataManagementSystem/" &> /dev/null & xdg-open "http://localhost:${1:-8080}" &>/dev/null & disown
+    /usr/bin/php -S "localhost:${1:-8080}" -t "$(determineDshDirectoryPath | sed 's/dsh//g')" &> /dev/null & xdg-open "http://localhost:${1:-8080}" &>/dev/null & disown
     exit 0
 }
 
@@ -114,7 +114,7 @@ determineAppDirectoryPath() {
 
 buildApp() {
     [[ -z "${1}" ]] && logErrorMsgAndExit1 "dsh --build-app <APP_NAME> <DOMAIN> expects the name of the app be specified as the first parameter."
-    [[ ! -d "$(determineAppDirectoryPath "${1}")" ]] && logErrorMsgAndExit1 "dsh --build-app <APP_NAME> <DOMAIN> expects the name of the app be specified as the first parameter."
+    [[ ! -d "$(determineAppDirectoryPath "${1}")" ]] && logErrorMsg "The specified App does not exist at $(determineAppDirectoryPath "${1}")" && notifyUser "The following Apps are available:" 0 'dontClear' && printf "\n\e[0m\e[102m\e[30m%s\e[0m\n" "$(ls Apps | sed 's/README.md//g' | column)" && logErrorMsgAndExit1 "Please specify an existing App."
     cd "$(determineAppDirectoryPath "${1}")"
     /usr/bin/php ./Components.php
     # Note to self: Remeber, an App's name is always the camel case alphanumeric form of the App's domain

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,49 +1,13 @@
 
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:30:44 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:30:47 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mTue Dec 22 03:10:45 PM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 03:10:48 PM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:31:26 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:31:29 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mTue Dec 22 02:32:06 AM EST 2020 assertNoError Passed[0m
-[0m[104m[30mTue Dec 22 02:32:11 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:34:00 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:34:03 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:35:52 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:35:55 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:36:40 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:36:43 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:37:43 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:37:46 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mTue Dec 22 03:10:58 PM EST 2020 assertError Passed[0m
+[0m[104m[30mTue Dec 22 03:11:02 PM EST 2020 testDshBuildAppRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mTue Dec 22 02:38:18 AM EST 2020 assertNoError Passed[0m
-[0m[104m[30mTue Dec 22 02:38:23 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:39:04 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:39:07 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mTue Dec 22 02:39:39 AM EST 2020 assertNoError Passed[0m
-[0m[104m[30mTue Dec 22 02:39:45 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mTue Dec 22 02:40:20 AM EST 2020 assertError Passed[0m
-[0m[104m[30mTue Dec 22 02:40:23 AM EST 2020 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mTue Dec 22 02:40:53 AM EST 2020 assertNoError Passed[0m
-[0m[104m[30mTue Dec 22 02:40:58 AM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m
+[0m[44m[30mTue Dec 22 05:00:48 PM EST 2020 assertNoError Passed[0m
+[0m[104m[30mTue Dec 22 05:00:53 PM EST 2020 testDshBuildAppBuildsSpecifiedApp Passed[0m


### PR DESCRIPTION
 DSH: Continued development of `dsh --build-app`. Implemented `testDshBuildAppRunsWithErrorIfSpecifiedAppDoesNotExist()` in `dsh/Tess/buildAppTests.sh`. All `dsh --build-app` tests are passing. This commit is related to issue #27.