### PR TITLE
DSH: Implemented dsh --new GlobalResponse

### DIFF
--- a/dsh/FileTemplates/GlobalResponse.php
+++ b/dsh/FileTemplates/GlobalResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+/** APP_NAME | GLOBAL_RESPONSE_NAME.php */
+
+use DarlingDataManagementSystem\classes\component\OutputComponent;
+use DarlingDataManagementSystem\classes\component\DynamicOutputComponent;
+
+$appComponentsFactory->buildGlobalResponse(
+    'GLOBAL_RESPONSE_NAME',
+    GLOBAL_RESPONSE_POSITION,
+);
+

--- a/dsh/Tests/newGlobalResponseTests.sh
+++ b/dsh/Tests/newGlobalResponseTests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# newGlobalResponseTests.sh
+
+set -o posix
+
+test_app_name="AppName${RANDOM}"
+showLoadingBar "Creating test App ${test_app_name} for use by tests defined in newGlobalResponses.sh" 'dontClear'
+dsh -n App "${test_app_name}" &> /dev/null
+
+expectedGlobalResponseFileContent() {
+    local expectedRESTemplateFilePath
+    expectedRESTemplateFilePath="$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/FileTemplates/GlobalResponse.php"
+    expectedContent="$(cat "${expectedRESTemplateFilePath}")"
+    [[ -z "${1}" ]] && logErrorMsgAndExit1 "Please specify the name of the App the new test GlobalResponse will be defined for."
+    [[ -z "${2}" ]] && logErrorMsgAndExit1 "Please specify a name to assign to the new test GlobalResponse."
+    [[ -z "${3}" ]] && logErrorMsgAndExit1 "Please specify a position to assign to the new test GlobalResponse."
+    [[ ! -f "${expectedRESTemplateFilePath}" ]] && logErrorMsgAndExit1 "The GlobalResponse.php file template does not exist at $(determineDshDirectoryPath)/FileTemplates/GlobalResponse.php!"
+    expectedContent="$(echo "${expectedContent}" | sed "s/APP_NAME/${1}/g")"
+    expectedContent="$(echo "${expectedContent}" | sed "s/GLOBAL_RESPONSE_NAME/${2}/g")"
+    expectedContent="$(echo "${expectedContent}" | sed "s/GLOBAL_RESPONSE_POSITION/${3}/g")"
+    printf "%s" "${expectedContent}"
+}
+
+testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified() {
+    assertError "dsh --new GlobalResponse" "dsh --new GlobalResponse <APP_NAME> <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION>  MUST run with an error if <APP_NAME> is not specified."
+}
+
+testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist() {
+    assertError "dsh --new GlobalResponse AppName${RANDOM} GRESName GRESPosition " "dsh --new GlobalResponse <APP_NAME> <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION>  MUST run with an error if App does not exist."
+}
+
+testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists() {
+    showLoadingBar "Creating test GlobalResponse GRESName for test App ${test_app_name} to be used by testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists()" 'dontClear'
+    dsh --new GlobalResponse ${test_app_name} GRESName GRESPosition  &> /dev/null
+    assertError "dsh --new GlobalResponse ${test_app_name} GRESName GRESPosition " "dsh --new GlobalResponse <APP_NAME> <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION>  MUST run with an error if an GlobalResponse named <GLOBAL_RESPONSE_NAME> is already defined for the secified App."
+}
+
+testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified() {
+    assertError "dsh --new GlobalResponse ${test_app_name}" "dsh --new GlobalResponse <APP_NAME> <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION>  MUST run with an error if <GLOBAL_RESPONSE_NAME> is not specified."
+}
+
+testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified() {
+    assertError "dsh --new GlobalResponse ${test_app_name} GRESName${RANDOM}" "dsh --new GlobalResponse <APP_NAME> <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION>  MUST run with an error if <GLOBAL_RESPONSE_POSITION> is not specified."
+}
+
+testNewGlobalResponseRunsWithErrorIfRELATIVE_URLIsNotSpecified() {
+    assertError "dsh --new GlobalResponse ${test_app_name} GRESName${RANDOM} GRESPosition" "dsh --new GlobalResponse <APP_NAME> <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION>  MUST run with an error if  is not specified."
+}
+
+testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp() {
+    local global_response_name
+    global_response_name="GRESName${RANDOM}"
+    assertFileExists "dsh --new GlobalResponse ${test_app_name} ${global_response_name} GRESPosition " "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}/Responses/${global_response_name}.php" "dsh --new GlobalResponse <GLOBAL_RESPONSE_NAME> <GLOBAL_RESPONSE_POSITION> <GLOBAL_RESPONSE_POSITION> <DYNAMIC_GLOBAL_RESPONSE_FILE> MUST create a GlobalResponse configuration file at Apps/<APP_NAME>/Responses/<GLOBAL_RESPONSE_NAME>.php"
+}
+
+testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent() {
+    local global_response_name
+    global_response_name="GRESName${RANDOM}"
+    dsh --new GlobalResponse ${test_app_name} ${global_response_name} GRESPosition
+    assertEquals "$(expectedGlobalResponseFileContent ${test_app_name} ${global_response_name} GRESPosition )" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}/Responses/${global_response_name}.php")"
+}
+
+runTest testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified
+runTest testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist
+runTest testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists
+runTest testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified
+runTest testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified
+runTest testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp
+runTest testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent
+
+[[ -d "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}" ]] && rm -R "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}"

--- a/dsh/Tests/newResponseTests.sh
+++ b/dsh/Tests/newResponseTests.sh
@@ -48,16 +48,16 @@ testNewResponseRunsWithErrorIfRELATIVE_URLIsNotSpecified() {
 }
 
 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp() {
-    local request_name
-    request_name="RESName${RANDOM}"
-    assertFileExists "dsh --new Response ${test_app_name} ${request_name} RESPosition " "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}/Responses/${request_name}.php" "dsh --new Response <RESPONSE_NAME> <RESPONSE_POSITION> <RESPONSE_POSITION> <DYNAMIC_RESPONSE_FILE> MUST create a Response configuration file at Apps/<APP_NAME>/Responses/<RESPONSE_NAME>.php"
+    local response_name
+    response_name="RESName${RANDOM}"
+    assertFileExists "dsh --new Response ${test_app_name} ${response_name} RESPosition " "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}/Responses/${response_name}.php" "dsh --new Response <RESPONSE_NAME> <RESPONSE_POSITION> <RESPONSE_POSITION> <DYNAMIC_RESPONSE_FILE> MUST create a Response configuration file at Apps/<APP_NAME>/Responses/<RESPONSE_NAME>.php"
 }
 
 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent() {
-    local request_name
-    request_name="RESName${RANDOM}"
-    dsh --new Response ${test_app_name} ${request_name} RESPosition
-    assertEquals "$(expectedResponseFileContent ${test_app_name} ${request_name} RESPosition )" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}/Responses/${request_name}.php")"
+    local response_name
+    response_name="RESName${RANDOM}"
+    dsh --new Response ${test_app_name} ${response_name} RESPosition
+    assertEquals "$(expectedResponseFileContent ${test_app_name} ${response_name} RESPosition )" "$(cat "$(determineDshUnitDirectoryPath | sed 's/dshUnit/Apps/g')/${test_app_name}/Responses/${response_name}.php")"
 }
 
 runTest testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -260,6 +260,25 @@ createNewResponse() {
     exit 0
 }
 
+createNewGlobalResponse() {
+    [[ -z "${1}" ]] && logErrorMsgAndExit1 "You must specify the name of the App the new GlobalResponse will be defined for."
+    [[ -z "${2}" ]] && logErrorMsgAndExit1 "You must specify a name to assign to the new GlobalResponse."
+    [[ -z "${3}" ]] && logErrorMsgAndExit1 "You must specify a position to assign to the new GlobalResponse."
+    [[ ! -d "$(determineAppDirectoryPath ${1})" ]] && logErrorMsg "The specified App, ${1}, does not exist. Please specify an existing App to define the new GlobalResponse for. The following apps are available:" && logErrorMsg "$(ls "$(determineDshDirectoryPath | sed 's/dsh/Apps/g')" | sed 's/README.md//g' | column)" && logErrorMsgAndExit1 "For help use dsh --help --new GlobalResponse."
+    [[ -f "$(determineAppDirectoryPath ${1})/Responses/${2}.php" ]] && logErrorMsgAndExit1 "A GlobalResponse named ${2} is already defined for the App, please specify a unique name to assign to the new GlobalResponse."
+    notifyUser "Creating new GlobalResponse \"${2}\" for the ${1} App:" 0 'dontClear'
+    showLoadingBar "    Copying $(determineDshDirectoryPath)/FileTemplates/GlobalResponse.php to $(determineAppDirectoryPath "${1}")" 'dontClear'
+    [[ ! -f "$(determineDshDirectoryPath)/FileTemplates/GlobalResponse.php" ]] && logErrorMsgAndExit1 "The GlobalResponse.php file template does not exist at $(determineDshDirectoryPath)/FileTemplates/GlobalResponse.php!"
+    cp "$(determineDshDirectoryPath)/FileTemplates/GlobalResponse.php" "$(determineAppDirectoryPath "${1}")/Responses/${2}.php"
+    showLoadingBar "    Configuring $(determineAppDirectoryPath "${1}")/Responses/${2}.php" 'dontClear'
+    sed -i "s/APP_NAME/${1}/g" "$(determineAppDirectoryPath "${1}")/Responses/${2}.php"
+    sed -i "s/GLOBAL_RESPONSE_NAME/${2}/g" "$(determineAppDirectoryPath "${1}")/Responses/${2}.php"
+    sed -i "s/GLOBAL_RESPONSE_POSITION/${3}/g" "$(determineAppDirectoryPath "${1}")/Responses/${2}.php"
+    notifyUser "The "${2}" GlobalResponse was defined for the ${1} App successfully. It's configuration file can be located at:" 0 'dontClear'
+    notifyUser "$(determineAppDirectoryPath "${1}")/Responses/${2}.php" 0 'dontClear'
+    exit 0
+}
+
 loadLibrary "$(determineDshDirectoryPath | sed 's/\/dsh//g')/dshUI/dshUI" "--theme dsh.sh"
 
 while test $# -gt 0; do
@@ -301,6 +320,11 @@ while test $# -gt 0; do
     Response)
       shift
       createNewResponse "${1}" "${2}" "${3}"
+      exit 0
+      ;;
+    GlobalResponse)
+      shift
+      createNewGlobalResponse "${1}" "${2}" "${3}"
       exit 0
       ;;
     esac

--- a/dsh/dshTestsConfig.sh
+++ b/dsh/dshTestsConfig.sh
@@ -43,4 +43,7 @@ if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'Test
     loadLibrary "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/Tests/newResponseTests.sh"
 fi
 
+if [[ "$(getSpecifiedTestGroup)" == 'all' || "$(getSpecifiedTestGroup)" == 'TestDshNewGlobalResponse' ]]; then
+    loadLibrary "$(determineDshUnitDirectoryPath | sed 's/dshUnit/dsh/g')/Tests/newGlobalResponseTests.sh"
+fi
 

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,29 +1,29 @@
 
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mSun Dec 27 03:56:42 PM EST 2020 assertError Passed[0m
-[0m[104m[30mSun Dec 27 03:56:45 PM EST 2020 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mSun Dec 27 05:27:51 PM EST 2020 assertError Passed[0m
+[0m[104m[30mSun Dec 27 05:27:54 PM EST 2020 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mSun Dec 27 03:56:58 PM EST 2020 assertError Passed[0m
-[0m[104m[30mSun Dec 27 03:57:02 PM EST 2020 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mSun Dec 27 05:28:08 PM EST 2020 assertError Passed[0m
+[0m[104m[30mSun Dec 27 05:28:12 PM EST 2020 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mSun Dec 27 03:57:22 PM EST 2020 assertError Passed[0m
-[0m[104m[30mSun Dec 27 03:57:26 PM EST 2020 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists     =-=-[0m
+[0m[44m[30mSun Dec 27 05:28:34 PM EST 2020 assertError Passed[0m
+[0m[104m[30mSun Dec 27 05:28:39 PM EST 2020 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mSun Dec 27 03:57:36 PM EST 2020 assertError Passed[0m
-[0m[104m[30mSun Dec 27 03:57:39 PM EST 2020 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mSun Dec 27 05:28:49 PM EST 2020 assertError Passed[0m
+[0m[104m[30mSun Dec 27 05:28:53 PM EST 2020 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mSun Dec 27 03:57:49 PM EST 2020 assertError Passed[0m
-[0m[104m[30mSun Dec 27 03:57:53 PM EST 2020 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified     =-=-[0m
+[0m[44m[30mSun Dec 27 05:29:04 PM EST 2020 assertError Passed[0m
+[0m[104m[30mSun Dec 27 05:29:08 PM EST 2020 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mSun Dec 27 03:58:09 PM EST 2020 assertFileExists Passed[0m
-[0m[104m[30mSun Dec 27 03:58:13 PM EST 2020 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp     =-=-[0m
+[0m[44m[30mSun Dec 27 05:29:26 PM EST 2020 assertFileExists Passed[0m
+[0m[104m[30mSun Dec 27 05:29:30 PM EST 2020 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mSun Dec 27 03:58:33 PM EST 2020 assertEquals Passed[0m
-[0m[104m[30mSun Dec 27 03:58:38 PM EST 2020 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mSun Dec 27 05:29:49 PM EST 2020 assertEquals Passed[0m
+[0m[104m[30mSun Dec 27 05:29:54 PM EST 2020 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m


### PR DESCRIPTION
Defined new test file at `dsh/Tests/newGlobalResponseTests.sh`

Implemented the following tests:

```
testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified()
testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist()
testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists()
testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified()
testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified()
testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp()
testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent()
```

All `dsh --new GlobalResponse` tests are passing.

This commit is related to issue #27.