### PR TITLE
DSH | DOCUMENTATION

### DIFF
--- a/dsh/Tests/helpFLAGTests.sh
+++ b/dsh/Tests/helpFLAGTests.sh
@@ -9,7 +9,7 @@ determineHelpFilesDirectoryPath() {
 
 expectedHelpFileOutput() {
     local text
-    text="$(dshUI -c "$(determineHelpFilesDirectoryPath)/${1}" 33 "dsh -.*[>]" "[<].*[>]" "dshUnit ")"
+    text="$(dshUI -c "$(determineHelpFilesDirectoryPath)/${1}" 93 "[<]\b[^>]*[>]" "[[]\b[^]]*[]]" "dsh --.*[^ A-Z]" "dsh -.*[^ A-Z]" "Darling Data Management System" "DDMS" "dshUnit" "dshUI" "http:\/\/localhost:" "8080")"
     printf "%s" "${text}"
 }
 

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -44,7 +44,7 @@ updateAndShowManPage() {
 
 showHelpFile() {
     local text
-    text="$(dshUI -c "$(determineDshDirectoryPath)/helpFiles/${1}" 33 "dsh -.*[>]" "[<].*[>]" "dshUnit ")"
+    text="$(dshUI -c "$(determineDshDirectoryPath)/helpFiles/${1}" 93 "[<]\b[^>]*[>]" "[[]\b[^]]*[]]" "dsh --.*[^ A-Z]" "dsh -.*[^ A-Z]" "Darling Data Management System" "DDMS" "dshUnit" "dshUI" "http:\/\/localhost:" "8080")"
     printf "%s" "${text}"
     exit 0
 }

--- a/dsh/helpFiles/helpFLAG.txt
+++ b/dsh/helpFiles/helpFLAG.txt
@@ -1,3 +1,42 @@
-dsh --help | -h <FLAG> : Detailed help information about the specified flag.
-For example, dsh -h --build-app would show detailed help information about the
---build-app flag.
+dsh --help | -h <FLAG> : Show detailed help information about the specified flag.
+
+The following options are possible:
+
+dsh --help --help
+dsh -h -h
+
+dsh --help --new
+dsh -h -n
+
+dsh --help --new App
+dsh -h -n App
+
+dsh --help --new OutputComponent
+dsh -h -n OutputComponent
+
+dsh --help --new DynamicOutputComponent
+dsh -h -n DynamicOutputComponent
+
+dsh --help --new Request
+dsh -h -n Request
+
+dsh --help --new Response
+dsh -h -n Response
+
+dsh --help --new GlobalResponse
+dsh -h -n GlobalResponse
+
+dsh --help --build-app
+dsh -h -b
+
+dsh --help --start-development-server
+dsh -h -s
+
+dsh --help --assign-to-response
+dsh -h -a
+
+dsh --help --dsh-unit
+dsh -h -d
+
+dsh --help --php-unit
+dsh -h -p

--- a/dsh/helpFiles/helpFlags.txt
+++ b/dsh/helpFiles/helpFlags.txt
@@ -1,1 +1,57 @@
-dsh --help flags : Show brief help information about all available flags.
+### dsh flags ###
+
+The following is a brief summary of all the flags available to dsh:
+
+dsh --help : Show help information about dsh
+Shorthand: Shorthand: dsh -h
+For more information use: dsh -h -h
+
+dsh --help flags : Show brief help information about all dsh flags
+Shorthand: dsh -h flags
+Your are currently viewing the output of dsh --help flags
+
+dsh --help [FLAG] : Show detailed help information about the specified flag.
+For example: dsh --help --new or dsh -h -n
+Shorthand: dsh -h [FLAG]
+For more information use: dsh -h FLAG
+
+dsh --new [MODE] [ARGUMENTS...] : The new flag is used to create. The new flag is
+modal, meaning the specified [MODE] determines what is created.
+Different modes expect different [ARGUMENTS...], and different modes may
+expect different numbers of [ARGUMENTS..].
+Shorthand: dsh -n [ARGUMENTS...]
+For more information use: dsh -h -n
+
+dsh --build-app | -b [APP_NAME] [DOMAIN] : Build an App for a
+specified [DOMAIN] by running php Apps/[APP_NAME]/Components.php.
+If [DOMAIN] is not specified then the domain defined in the App's
+Components.php file will be used. If the specified App was already built for the
+specified [DOMAIN], then the App will not be built, an error will be logged,
+and dsh will exit.
+Shorthand: dsh -b
+For more information use: dsh -h -b
+
+dsh --start-development-server | -s [PORT] : Start a development server at
+http://localhost:[PORT]. If [PORT] is not specified start a development
+server at http://localhost:8080.
+Shorthand: dsh -s
+For more information use: dsh -h -s
+
+dsh --assign-to-response [APP_NAME] [COMPONENT_NAME] [COMPONENT_TYPE] [COMPONENT_CONTAINER] [RESPONSE_NAME] :
+Assign the component defined for the [APP_NAME] app whose name is [COMPONENT_NAME] and type is [COMPONENT_TYPE]
+to the response defined for the [APP_NAME] app whose name is [RESPONSE_NAME].
+Shorthand: dsh -a
+For more information use: dsh -h -a
+
+dsh --dsh-unit <DSH_UNIT_CONFIG_FILE_PATH> <TEST_GROUP_NAME> Run dshUnit tests.
+If <DSH_UNIT_CONFIG_FILE_PATH> is specified it will be used, otherwise dshUnit's
+dshUnitConfig.sh file will be used. If <TEST_GROUP_NAME> is specified, then the
+specified test group will be run, otherwise the all test group will be run.
+Shorthand: dsh -d
+For more information use: dsh -h -d
+
+dsh --php-unit <PHP_UNIT_CONFIG_FILE_PATH> Run PhpUnit tests. If <PHP_UNIT_CONFIG_FILE_PATH>
+is specified it will be used, otherwise the Darling Data Management System's php.xml
+file will be used.
+Shorthand: dsh -p
+For more information use: dsh -h -p

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,646 +1,646 @@
 
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:23:40 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:23:42 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:23:45 PM EST 2021 testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:23:59 PM EST 2021 assertNoError Failed[0m
-[0m[44m[30mFri Jan  1 12:24:00 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:24:05 PM EST 2021 testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:24:13 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:24:19 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:24:24 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:24:28 PM EST 2021 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:24:40 PM EST 2021 assertNoError Failed[0m
-[0m[43m[30mFri Jan  1 12:24:46 PM EST 2021 assertNoError Failed[0m
-[0m[43m[30mFri Jan  1 12:24:53 PM EST 2021 assertNoError Failed[0m
-[0m[104m[30mFri Jan  1 12:24:57 PM EST 2021 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:25:07 PM EST 2021 assertError Failed[0m
-[0m[44m[30mFri Jan  1 12:25:08 PM EST 2021 assertNoError Passed[0m
-[0m[43m[30mFri Jan  1 12:25:15 PM EST 2021 assertError Failed[0m
-[0m[44m[30mFri Jan  1 12:25:16 PM EST 2021 assertNoError Passed[0m
-[0m[43m[30mFri Jan  1 12:25:23 PM EST 2021 assertError Failed[0m
-[0m[44m[30mFri Jan  1 12:25:25 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:25:29 PM EST 2021 testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:25:39 PM EST 2021 assertError Failed[0m
-[0m[44m[30mFri Jan  1 12:25:40 PM EST 2021 assertNoError Passed[0m
-[0m[43m[30mFri Jan  1 12:25:47 PM EST 2021 assertError Failed[0m
-[0m[44m[30mFri Jan  1 12:25:48 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:25:52 PM EST 2021 testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:26:03 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:26:07 PM EST 2021 testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:26:15 PM EST 2021 assertError Failed[0m
-[0m[43m[30mFri Jan  1 12:26:20 PM EST 2021 assertError Failed[0m
-[0m[43m[30mFri Jan  1 12:26:26 PM EST 2021 assertError Failed[0m
-[0m[104m[30mFri Jan  1 12:26:31 PM EST 2021 testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:26:47 PM EST 2021 assertErrorIfDirectoryExists Passed[0m
-[0m[44m[30mFri Jan  1 12:26:48 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:26:52 PM EST 2021 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:27:08 PM EST 2021 assertErrorIfDirectoryExists Passed[0m
-[0m[44m[30mFri Jan  1 12:27:09 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:27:14 PM EST 2021 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:27:27 PM EST 2021 assertErrorIfDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:27:32 PM EST 2021 testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:27:40 PM EST 2021 assertErrorIfDirectoryExists Failed[0m
-[0m[104m[30mFri Jan  1 12:27:44 PM EST 2021 testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:27:59 PM EST 2021 assertErrorIfFileExists Passed[0m
-[0m[44m[30mFri Jan  1 12:28:00 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:28:04 PM EST 2021 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:28:20 PM EST 2021 assertErrorIfFileExists Passed[0m
-[0m[44m[30mFri Jan  1 12:28:21 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:28:26 PM EST 2021 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:28:37 PM EST 2021 assertErrorIfFileExists Passed[0m
-[0m[104m[30mFri Jan  1 12:28:41 PM EST 2021 testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:28:49 PM EST 2021 assertErrorIfFileExists Failed[0m
-[0m[104m[30mFri Jan  1 12:28:53 PM EST 2021 testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:29:06 PM EST 2021 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:29:08 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:29:13 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:29:28 PM EST 2021 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:29:30 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:29:35 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:29:46 PM EST 2021 assertErrorIfDirectoryDoesNotExist Passed[0m
-[0m[104m[30mFri Jan  1 12:29:51 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:29:59 PM EST 2021 assertErrorIfDirectoryDoesNotExist Failed[0m
-[0m[104m[30mFri Jan  1 12:30:05 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:30:22 PM EST 2021 assertErrorIfFileDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:30:23 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:30:28 PM EST 2021 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:30:43 PM EST 2021 assertErrorIfFileDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:30:45 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:30:50 PM EST 2021 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:31:01 PM EST 2021 assertErrorIfFileDoesNotExist Passed[0m
-[0m[104m[30mFri Jan  1 12:31:06 PM EST 2021 testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:31:15 PM EST 2021 assertErrorIfFileDoesNotExist Failed[0m
-[0m[104m[30mFri Jan  1 12:31:20 PM EST 2021 testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:31:35 PM EST 2021 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[44m[30mFri Jan  1 12:31:36 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:31:42 PM EST 2021 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:31:57 PM EST 2021 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[44m[30mFri Jan  1 12:31:58 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:32:04 PM EST 2021 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:32:16 PM EST 2021 assertErrorIfFileIsNotExecutable Passed[0m
-[0m[104m[30mFri Jan  1 12:32:21 PM EST 2021 testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:32:30 PM EST 2021 assertErrorIfFileIsNotExecutable Failed[0m
-[0m[104m[30mFri Jan  1 12:32:35 PM EST 2021 testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:32:49 PM EST 2021 assertDirectoryExists Failed[0m
-[0m[44m[30mFri Jan  1 12:32:50 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:32:54 PM EST 2021 testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:33:09 PM EST 2021 assertDirectoryExists Failed[0m
-[0m[44m[30mFri Jan  1 12:33:10 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:33:15 PM EST 2021 testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:33:22 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:33:27 PM EST 2021 testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:33:38 PM EST 2021 assertDirectoryExists Failed[0m
-[0m[104m[30mFri Jan  1 12:33:42 PM EST 2021 testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:33:56 PM EST 2021 assertDirectoryDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:33:57 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:34:02 PM EST 2021 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:34:17 PM EST 2021 assertDirectoryDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:34:19 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:34:24 PM EST 2021 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:34:35 PM EST 2021 assertDirectoryDoesNotExist Passed[0m
-[0m[104m[30mFri Jan  1 12:34:39 PM EST 2021 testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:34:48 PM EST 2021 assertDirectoryDoesNotExist Failed[0m
-[0m[104m[30mFri Jan  1 12:34:52 PM EST 2021 testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:35:07 PM EST 2021 assertFileExists Failed[0m
-[0m[44m[30mFri Jan  1 12:35:08 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:35:13 PM EST 2021 testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:35:32 PM EST 2021 assertFileExists Failed[0m
-[0m[44m[30mFri Jan  1 12:35:34 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:35:38 PM EST 2021 testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:35:47 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 12:35:51 PM EST 2021 testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:36:02 PM EST 2021 assertFileExists Failed[0m
-[0m[104m[30mFri Jan  1 12:36:06 PM EST 2021 testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:36:24 PM EST 2021 assertFileDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:36:25 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:36:30 PM EST 2021 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:36:43 PM EST 2021 assertFileDoesNotExist Passed[0m
-[0m[44m[30mFri Jan  1 12:36:45 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:36:49 PM EST 2021 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:36:59 PM EST 2021 assertFileDoesNotExist Passed[0m
-[0m[104m[30mFri Jan  1 12:37:04 PM EST 2021 testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:37:12 PM EST 2021 assertFileDoesNotExist Failed[0m
-[0m[104m[30mFri Jan  1 12:37:17 PM EST 2021 testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:37:26 PM EST 2021 assertEquals Failed[0m
-[0m[44m[30mFri Jan  1 12:37:27 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:37:31 PM EST 2021 testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:37:40 PM EST 2021 assertEquals Passed[0m
-[0m[44m[30mFri Jan  1 12:37:41 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:37:45 PM EST 2021 testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:37:52 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:37:56 PM EST 2021 testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:38:03 PM EST 2021 assertEquals Failed[0m
-[0m[104m[30mFri Jan  1 12:38:07 PM EST 2021 testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
-[0m[43m[30mFri Jan  1 12:38:18 PM EST 2021 assertNotEquals Failed[0m
-[0m[44m[30mFri Jan  1 12:38:19 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:38:23 PM EST 2021 testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
-[0m[44m[30mFri Jan  1 12:38:32 PM EST 2021 assertNotEquals Passed[0m
-[0m[44m[30mFri Jan  1 12:38:34 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:38:38 PM EST 2021 testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
-[0m[44m[30mFri Jan  1 12:38:45 PM EST 2021 assertNotEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:38:49 PM EST 2021 testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
-[0m[43m[30mFri Jan  1 12:38:56 PM EST 2021 assertNotEquals Failed[0m
-[0m[104m[30mFri Jan  1 12:39:00 PM EST 2021 testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
-
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpRunsWithoutError     =-=-[0m
-[0m[44m[30mFri Jan  1 12:39:16 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:39:20 PM EST 2021 testDshHelpRunsWithoutError Passed[0m
+[0m[44m[30mFri Jan  1 09:43:15 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 09:43:18 PM EST 2021 testDshHelpRunsWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpCreatesSystemManPageForDsh     =-=-[0m
-[0m[44m[30mFri Jan  1 12:39:28 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 12:39:32 PM EST 2021 testDshHelpCreatesSystemManPageForDsh Passed[0m
+[0m[44m[30mFri Jan  1 09:43:25 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 09:43:28 PM EST 2021 testDshHelpCreatesSystemManPageForDsh Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpOutputMatchesManDshOutput     =-=-[0m
-[0m[43m[30mFri Jan  1 12:39:41 PM EST 2021 assertEquals Failed[0m
-[0m[103m[30mFri Jan  1 12:39:44 PM EST 2021 testDshHelpOutputMatchesManDshOutput Failed[0m
+[0m[44m[30mFri Jan  1 09:44:12 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:44:15 PM EST 2021 testDshHelpOutputMatchesManDshOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid     =-=-[0m
-[0m[44m[30mFri Jan  1 12:39:55 PM EST 2021 assertError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:03 PM EST 2021 assertError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:13 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:40:17 PM EST 2021 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
+[0m[44m[30mFri Jan  1 09:44:25 PM EST 2021 assertError Passed[0m
+[0m[44m[30mFri Jan  1 09:44:33 PM EST 2021 assertError Passed[0m
+[0m[44m[30mFri Jan  1 09:44:41 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 09:44:45 PM EST 2021 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid     =-=-[0m
-[0m[44m[30mFri Jan  1 12:40:24 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:28 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:32 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:37 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:41 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:45 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:48 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:52 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:40:57 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:02 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:06 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:12 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:16 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:20 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:25 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:28 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:33 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:37 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:41 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:45 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:49 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:52 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:41:56 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:01 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:06 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:11 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:17 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:21 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:25 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:42:31 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:42:35 PM EST 2021 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
+[0m[44m[30mFri Jan  1 09:44:52 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:44:56 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:00 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:05 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:09 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:14 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:18 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:23 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:27 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:32 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:36 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:41 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:45 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:50 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:54 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:45:59 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:03 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:07 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:12 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:16 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:20 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:25 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:29 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:34 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:38 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:43 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:47 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:51 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:46:56 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:47:00 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 09:47:04 PM EST 2021 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent     =-=-[0m
-[0m[44m[30mFri Jan  1 12:42:42 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:42:46 PM EST 2021 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
+[0m[44m[30mFri Jan  1 09:47:11 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:47:15 PM EST 2021 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent     =-=-[0m
-[0m[44m[30mFri Jan  1 12:42:57 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:43:02 PM EST 2021 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
+[0m[44m[30mFri Jan  1 09:47:41 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:47:45 PM EST 2021 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:43:10 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:43:14 PM EST 2021 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:48:52 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:48:56 PM EST 2021 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:43:27 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:43:33 PM EST 2021 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:49:08 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:49:13 PM EST 2021 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:43:48 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:43:52 PM EST 2021 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:49:28 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:49:32 PM EST 2021 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:44:11 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:44:15 PM EST 2021 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:49:53 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:49:57 PM EST 2021 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:45:09 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:45:13 PM EST 2021 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:50:48 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:50:52 PM EST 2021 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:45:43 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:45:48 PM EST 2021 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:51:16 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:51:21 PM EST 2021 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:46:20 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:46:26 PM EST 2021 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:51:50 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:51:55 PM EST 2021 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:46:48 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:46:53 PM EST 2021 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:52:18 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:52:22 PM EST 2021 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:47:51 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:47:55 PM EST 2021 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:53:20 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:53:24 PM EST 2021 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:48:44 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:48:48 PM EST 2021 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:54:07 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:54:12 PM EST 2021 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:49:28 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:49:33 PM EST 2021 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:54:48 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:54:53 PM EST 2021 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:49:44 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:49:49 PM EST 2021 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:55:04 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:55:08 PM EST 2021 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput     =-=-[0m
-[0m[44m[30mFri Jan  1 12:50:04 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:50:10 PM EST 2021 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m
+[0m[44m[30mFri Jan  1 09:55:22 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:55:27 PM EST 2021 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerStartsADevelopmentServerWithoutError     =-=-[0m
-[0m[44m[30mFri Jan  1 12:50:21 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 12:50:26 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:50:31 PM EST 2021 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
+[0m[44m[30mFri Jan  1 09:55:36 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 09:55:41 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:55:45 PM EST 2021 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:50:41 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:50:45 PM EST 2021 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 09:55:55 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:55:59 PM EST 2021 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:50:56 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 12:51:00 PM EST 2021 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
+[0m[44m[30mFri Jan  1 09:56:09 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 09:56:13 PM EST 2021 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:51:12 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:51:16 PM EST 2021 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 09:56:24 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 09:56:27 PM EST 2021 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 12:51:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:51:34 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 09:56:39 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 09:56:44 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 12:54:01 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:54:06 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 09:59:31 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 09:59:35 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 12:54:42 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mFri Jan  1 12:54:48 PM EST 2021 testDshBuildAppBuildsSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:00:04 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:00:11 PM EST 2021 testDshBuildAppBuildsSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:55:44 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:55:52 PM EST 2021 testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:00:46 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:00:54 PM EST 2021 testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:56:30 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:56:38 PM EST 2021 testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:01:24 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:01:32 PM EST 2021 testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:56:48 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:56:51 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:01:42 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:01:45 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotValid     =-=-[0m
-[0m[44m[30mFri Jan  1 12:57:07 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:57:11 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotValid Passed[0m
+[0m[44m[30mFri Jan  1 10:02:01 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:02:04 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 12:57:25 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:57:29 PM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:02:18 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:02:21 PM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME     =-=-[0m
-[0m[44m[30mFri Jan  1 12:58:00 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 12:58:05 PM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
+[0m[44m[30mFri Jan  1 10:02:58 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:03:01 PM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 12:58:33 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:58:36 PM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:03:32 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:03:35 PM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsOutputComponentsDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 12:59:03 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:59:07 PM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:04:07 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:04:10 PM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsRequestsDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 12:59:38 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 12:59:42 PM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:04:42 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:04:45 PM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsResponsesDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 01:00:11 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 01:00:15 PM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:05:16 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:05:20 PM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDynamicOutputDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 01:00:47 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 01:00:51 PM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:05:51 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:05:54 PM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsCssDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 01:01:21 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 01:01:26 PM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:06:25 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:06:28 PM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsJsDirectory     =-=-[0m
-[0m[44m[30mFri Jan  1 01:01:57 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mFri Jan  1 01:02:00 PM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
+[0m[44m[30mFri Jan  1 10:06:59 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:07:02 PM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFile     =-=-[0m
-[0m[44m[30mFri Jan  1 01:02:29 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 01:02:33 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
+[0m[44m[30mFri Jan  1 10:07:33 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:07:37 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate     =-=-[0m
-[0m[44m[30mFri Jan  1 01:03:02 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mFri Jan  1 01:03:34 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:03:39 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
+[0m[44m[30mFri Jan  1 10:08:10 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 10:08:38 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:08:43 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:04:12 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:04:16 PM EST 2021 testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:09:20 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:09:24 PM EST 2021 testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 01:04:31 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:04:35 PM EST 2021 testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:09:39 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:09:43 PM EST 2021 testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mFri Jan  1 01:05:00 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:05:06 PM EST 2021 testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
+[0m[44m[30mFri Jan  1 10:10:08 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:10:13 PM EST 2021 testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:05:20 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:05:24 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:10:25 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:10:29 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:05:36 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:05:41 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:10:41 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:10:46 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:05:53 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:05:58 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:10:58 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:11:02 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:06:11 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:06:15 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:11:14 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:11:17 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:06:35 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 01:06:40 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:11:37 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:11:41 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mFri Jan  1 01:06:58 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:07:04 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mFri Jan  1 10:12:00 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:12:06 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:07:38 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:07:42 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:12:44 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:12:48 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 01:07:58 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:08:03 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:13:04 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:13:08 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mFri Jan  1 01:08:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:08:35 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
+[0m[44m[30mFri Jan  1 10:13:35 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:13:41 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:08:49 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:08:53 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:13:54 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:13:58 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:09:07 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:09:12 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:14:11 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:14:16 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:09:26 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:09:32 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:14:29 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:14:34 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:09:45 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:09:49 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:14:47 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:14:51 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:10:11 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 01:10:17 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:15:11 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:15:16 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mFri Jan  1 01:10:38 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:10:45 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mFri Jan  1 10:15:36 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:15:41 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:11:18 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:11:23 PM EST 2021 testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:16:17 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:16:21 PM EST 2021 testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 01:11:38 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:11:42 PM EST 2021 testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:16:35 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:16:38 PM EST 2021 testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mFri Jan  1 01:12:05 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:12:10 PM EST 2021 testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists Passed[0m
+[0m[44m[30mFri Jan  1 10:17:02 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:17:06 PM EST 2021 testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:12:24 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:12:29 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:17:17 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:17:21 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:12:41 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:12:45 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:17:32 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:17:36 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:12:56 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:12:59 PM EST 2021 testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:17:47 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:17:50 PM EST 2021 testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:13:20 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 01:13:25 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:18:08 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:18:12 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mFri Jan  1 01:13:46 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:13:51 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mFri Jan  1 10:18:31 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:18:36 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:14:21 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:14:25 PM EST 2021 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:19:12 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:19:16 PM EST 2021 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 01:14:38 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:14:42 PM EST 2021 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:19:29 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:19:33 PM EST 2021 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mFri Jan  1 01:15:05 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:15:10 PM EST 2021 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
+[0m[44m[30mFri Jan  1 10:19:57 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:20:01 PM EST 2021 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:15:22 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:15:27 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:20:12 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:20:16 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:15:38 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:15:42 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:20:26 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:20:30 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:16:00 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 01:16:05 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:20:48 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:20:53 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mFri Jan  1 01:16:28 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:16:34 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mFri Jan  1 10:21:14 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:21:19 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:17:07 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:17:12 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:21:56 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:22:00 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 01:17:29 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:17:34 PM EST 2021 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:22:14 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:22:18 PM EST 2021 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mFri Jan  1 01:17:59 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:18:04 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
+[0m[44m[30mFri Jan  1 10:22:43 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:22:48 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:18:16 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:18:20 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:22:59 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:23:04 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:18:33 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:18:37 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:23:15 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:23:20 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:18:56 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mFri Jan  1 01:19:00 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:23:39 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:23:43 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mFri Jan  1 01:19:21 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:19:27 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mFri Jan  1 10:24:04 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:24:10 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:20:13 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:20:18 PM EST 2021 testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:24:56 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:25:00 PM EST 2021 testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:20:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:20:34 PM EST 2021 testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:25:11 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:25:15 PM EST 2021 testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:20:46 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:20:50 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:25:27 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:25:31 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:21:01 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:21:05 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:25:42 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:25:46 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified     =-=-[0m
-[0m[44m[30mFri Jan  1 01:21:17 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:21:21 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified Passed[0m
+[0m[44m[30mFri Jan  1 10:25:57 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:26:01 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mFri Jan  1 01:21:35 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:21:39 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:26:14 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:26:18 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:21:53 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:21:58 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:26:31 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:26:36 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp     =-=-[0m
-[0m[44m[30mFri Jan  1 01:22:11 PM EST 2021 assertError Passed[0m
-[0m[44m[30mFri Jan  1 01:22:22 PM EST 2021 assertError Passed[0m
-[0m[44m[30mFri Jan  1 01:22:32 PM EST 2021 assertError Passed[0m
-[0m[104m[30mFri Jan  1 01:22:36 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp Passed[0m
+[0m[44m[30mFri Jan  1 10:26:48 PM EST 2021 assertError Passed[0m
+[0m[44m[30mFri Jan  1 10:26:56 PM EST 2021 assertError Passed[0m
+[0m[44m[30mFri Jan  1 10:27:05 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:27:10 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseProducesExpectedResponseConfiguration     =-=-[0m
-[0m[44m[30mFri Jan  1 01:23:19 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mFri Jan  1 01:23:23 PM EST 2021 testDshAssignToResponseProducesExpectedResponseConfiguration Passed[0m
+[0m[44m[30mFri Jan  1 10:27:49 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:27:53 PM EST 2021 testDshAssignToResponseProducesExpectedResponseConfiguration Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:28:10 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 10:28:11 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:28:15 PM EST 2021 testAssertNoErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:28:30 PM EST 2021 assertNoError Failed[0m
+[0m[44m[30mFri Jan  1 10:28:31 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:28:36 PM EST 2021 testAssertNoErrorCapturesButDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:28:43 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 10:28:48 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mFri Jan  1 10:28:52 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:28:56 PM EST 2021 testAssertNoErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:29:07 PM EST 2021 assertNoError Failed[0m
+[0m[43m[30mFri Jan  1 10:29:15 PM EST 2021 assertNoError Failed[0m
+[0m[43m[30mFri Jan  1 10:29:22 PM EST 2021 assertNoError Failed[0m
+[0m[104m[30mFri Jan  1 10:29:26 PM EST 2021 testAssertNoErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:29:36 PM EST 2021 assertError Failed[0m
+[0m[44m[30mFri Jan  1 10:29:37 PM EST 2021 assertNoError Passed[0m
+[0m[43m[30mFri Jan  1 10:29:44 PM EST 2021 assertError Failed[0m
+[0m[44m[30mFri Jan  1 10:29:45 PM EST 2021 assertNoError Passed[0m
+[0m[43m[30mFri Jan  1 10:29:53 PM EST 2021 assertError Failed[0m
+[0m[44m[30mFri Jan  1 10:29:54 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:29:58 PM EST 2021 testAssertErrorDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:30:07 PM EST 2021 assertError Failed[0m
+[0m[44m[30mFri Jan  1 10:30:08 PM EST 2021 assertNoError Passed[0m
+[0m[43m[30mFri Jan  1 10:30:16 PM EST 2021 assertError Failed[0m
+[0m[44m[30mFri Jan  1 10:30:17 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:30:21 PM EST 2021 testAssertErrorDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:30:32 PM EST 2021 assertError Passed[0m
+[0m[104m[30mFri Jan  1 10:30:35 PM EST 2021 testAssertErrorIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:30:43 PM EST 2021 assertError Failed[0m
+[0m[43m[30mFri Jan  1 10:30:48 PM EST 2021 assertError Failed[0m
+[0m[43m[30mFri Jan  1 10:30:53 PM EST 2021 assertError Failed[0m
+[0m[104m[30mFri Jan  1 10:30:57 PM EST 2021 testAssertErrorIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:31:12 PM EST 2021 assertErrorIfDirectoryExists Passed[0m
+[0m[44m[30mFri Jan  1 10:31:13 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:31:18 PM EST 2021 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:31:33 PM EST 2021 assertErrorIfDirectoryExists Passed[0m
+[0m[44m[30mFri Jan  1 10:31:34 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:31:38 PM EST 2021 testAssertErrorIfDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:31:49 PM EST 2021 assertErrorIfDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:31:54 PM EST 2021 testAssertErrorIfDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:32:02 PM EST 2021 assertErrorIfDirectoryExists Failed[0m
+[0m[104m[30mFri Jan  1 10:32:06 PM EST 2021 testAssertErrorIfDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:32:21 PM EST 2021 assertErrorIfFileExists Passed[0m
+[0m[44m[30mFri Jan  1 10:32:22 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:32:27 PM EST 2021 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:32:42 PM EST 2021 assertErrorIfFileExists Passed[0m
+[0m[44m[30mFri Jan  1 10:32:43 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:32:47 PM EST 2021 testAssertErrorIfFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:32:58 PM EST 2021 assertErrorIfFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:33:02 PM EST 2021 testAssertErrorIfFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:33:10 PM EST 2021 assertErrorIfFileExists Failed[0m
+[0m[104m[30mFri Jan  1 10:33:14 PM EST 2021 testAssertErrorIfFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:33:29 PM EST 2021 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:33:30 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:33:34 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:33:49 PM EST 2021 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:33:50 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:33:54 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:34:05 PM EST 2021 assertErrorIfDirectoryDoesNotExist Passed[0m
+[0m[104m[30mFri Jan  1 10:34:10 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:34:18 PM EST 2021 assertErrorIfDirectoryDoesNotExist Failed[0m
+[0m[104m[30mFri Jan  1 10:34:23 PM EST 2021 testAssertErrorIfDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:34:37 PM EST 2021 assertErrorIfFileDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:34:38 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:34:42 PM EST 2021 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:34:56 PM EST 2021 assertErrorIfFileDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:34:58 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:35:02 PM EST 2021 testAssertErrorIfFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:35:12 PM EST 2021 assertErrorIfFileDoesNotExist Passed[0m
+[0m[104m[30mFri Jan  1 10:35:17 PM EST 2021 testAssertErrorIfFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:35:25 PM EST 2021 assertErrorIfFileDoesNotExist Failed[0m
+[0m[104m[30mFri Jan  1 10:35:29 PM EST 2021 testAssertErrorIfFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:35:44 PM EST 2021 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[44m[30mFri Jan  1 10:35:45 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:35:49 PM EST 2021 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:36:03 PM EST 2021 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[44m[30mFri Jan  1 10:36:05 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:36:09 PM EST 2021 testAssertErrorIfFileIsNotExecutableDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:36:20 PM EST 2021 assertErrorIfFileIsNotExecutable Passed[0m
+[0m[104m[30mFri Jan  1 10:36:24 PM EST 2021 testAssertErrorIfFileIsNotExecutableIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:36:33 PM EST 2021 assertErrorIfFileIsNotExecutable Failed[0m
+[0m[104m[30mFri Jan  1 10:36:37 PM EST 2021 testAssertErrorIfFileIsNotExecutableIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:36:51 PM EST 2021 assertDirectoryExists Failed[0m
+[0m[44m[30mFri Jan  1 10:36:52 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:36:56 PM EST 2021 testAssertDirectoryExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:37:11 PM EST 2021 assertDirectoryExists Failed[0m
+[0m[44m[30mFri Jan  1 10:37:12 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:37:16 PM EST 2021 testAssertDirectoryExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:37:24 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mFri Jan  1 10:37:28 PM EST 2021 testAssertDirectoryExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:37:38 PM EST 2021 assertDirectoryExists Failed[0m
+[0m[104m[30mFri Jan  1 10:37:42 PM EST 2021 testAssertDirectoryExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:37:57 PM EST 2021 assertDirectoryDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:37:58 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:38:03 PM EST 2021 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:38:17 PM EST 2021 assertDirectoryDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:38:18 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:38:22 PM EST 2021 testAssertDirectoryDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:38:33 PM EST 2021 assertDirectoryDoesNotExist Passed[0m
+[0m[104m[30mFri Jan  1 10:38:37 PM EST 2021 testAssertDirectoryDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:38:45 PM EST 2021 assertDirectoryDoesNotExist Failed[0m
+[0m[104m[30mFri Jan  1 10:38:49 PM EST 2021 testAssertDirectoryDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:39:03 PM EST 2021 assertFileExists Failed[0m
+[0m[44m[30mFri Jan  1 10:39:04 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:39:08 PM EST 2021 testAssertFileExistsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:39:23 PM EST 2021 assertFileExists Failed[0m
+[0m[44m[30mFri Jan  1 10:39:24 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:39:28 PM EST 2021 testAssertFileExistsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:39:35 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mFri Jan  1 10:39:39 PM EST 2021 testAssertFileExistsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:39:49 PM EST 2021 assertFileExists Failed[0m
+[0m[104m[30mFri Jan  1 10:39:53 PM EST 2021 testAssertFileExistsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:40:08 PM EST 2021 assertFileDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:40:09 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:40:14 PM EST 2021 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:40:27 PM EST 2021 assertFileDoesNotExist Passed[0m
+[0m[44m[30mFri Jan  1 10:40:28 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:40:33 PM EST 2021 testAssertFileDoesNotExistDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:40:43 PM EST 2021 assertFileDoesNotExist Passed[0m
+[0m[104m[30mFri Jan  1 10:40:47 PM EST 2021 testAssertFileDoesNotExistIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:40:55 PM EST 2021 assertFileDoesNotExist Failed[0m
+[0m[104m[30mFri Jan  1 10:40:59 PM EST 2021 testAssertFileDoesNotExistIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:41:08 PM EST 2021 assertEquals Failed[0m
+[0m[44m[30mFri Jan  1 10:41:09 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:41:13 PM EST 2021 testAssertEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:41:23 PM EST 2021 assertEquals Passed[0m
+[0m[44m[30mFri Jan  1 10:41:24 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:41:28 PM EST 2021 testAssertEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:41:35 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:41:39 PM EST 2021 testAssertEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:41:46 PM EST 2021 assertEquals Failed[0m
+[0m[104m[30mFri Jan  1 10:41:50 PM EST 2021 testAssertEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected     =-=-[0m
+[0m[43m[30mFri Jan  1 10:42:00 PM EST 2021 assertNotEquals Failed[0m
+[0m[44m[30mFri Jan  1 10:42:01 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:42:05 PM EST 2021 testAssertNotEqualsDoesNotProduceAnErrorWhenFailingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected     =-=-[0m
+[0m[44m[30mFri Jan  1 10:42:15 PM EST 2021 assertNotEquals Passed[0m
+[0m[44m[30mFri Jan  1 10:42:17 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mFri Jan  1 10:42:21 PM EST 2021 testAssertNotEqualsDoesNotProduceAnErrorWhenPassingAssertionIsExpected Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion     =-=-[0m
+[0m[44m[30mFri Jan  1 10:42:28 PM EST 2021 assertNotEquals Passed[0m
+[0m[104m[30mFri Jan  1 10:42:32 PM EST 2021 testAssertNotEqualsIncreasesPASSING_ASSERTIONSOnPassingAssertion Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion     =-=-[0m
+[0m[43m[30mFri Jan  1 10:42:39 PM EST 2021 assertNotEquals Failed[0m
+[0m[104m[30mFri Jan  1 10:42:43 PM EST 2021 testAssertNotEqualsIncreasesFAILING_ASSERTIONSOnFailingAssertion Passed[0m


### PR DESCRIPTION
DSH | DOCUMENTATION: Refactored regular expressions used by `dsh/Tests/helpFLAGTests.sh::expectedHelpFileOutput()` and `dsh/dsh::showHelpFile()` to colorize help file output. Revised `dsh/helpFiles/helpFLAG.txt` and `dsh/helpFiles/helpFlags.txt`. Ran all **dsh** and **dshUnit** tests, all tests are passing. This is related to issues #6 and #27