### PR TITLE
Addressing issue #100  and issue #83

### DIFF
--- a/dsh/Tests/helpFLAGTests.sh
+++ b/dsh/Tests/helpFLAGTests.sh
@@ -39,6 +39,9 @@ testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid() {
     assertNoError "dsh --help --assign-to-response" "dsh --help --assign-to-response MUST run without error."
     assertNoError "dsh --help --php-unit" "dsh --help --php-unit MUST run without error."
     assertNoError "dsh --help --dsh-unit" "dsh --help --dsh-unit MUST run without error."
+
+    assertNoError "dsh --help --locate-ddms-directory" "dsh --help --locate-ddms-directory MUST run without error."
+
     # short form tests
     assertNoError "dsh -h -h" "dsh -h -h MUST run without error."
     assertNoError "dsh -h FLAG" "dsh -h FLAG MUST run without error."
@@ -47,6 +50,9 @@ testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid() {
     assertNoError "dsh -h -b" "dsh -h -b MUST run without error."
     assertNoError "dsh -h -n" "dsh -h -n MUST run without error."
     assertNoError "dsh -h -n App" "dsh -h -n App MUST run without error."
+
+    assertNoError "dsh -h -n AppPackage" "dsh -h -n AppPackage MUST run without error."
+
     assertNoError "dsh -h -n OutputComponent" "dsh -h -n OutputComponent MUST run without error."
     assertNoError "dsh -h -n DynamicOutputComponent" "dsh -h -n DynamicOutputComponent MUST run without error."
     assertNoError "dsh -h -n Request" "dsh -h -n Request MUST run without error."
@@ -55,6 +61,8 @@ testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid() {
     assertNoError "dsh -h -a" "dsh -h -a MUST run without error."
     assertNoError "dsh -h -p" "dsh -h -p MUST run without error."
     assertNoError "dsh -h -d" "dsh -h -d MUST run without error."
+
+    assertNoError "dsh -h -l" "dsh --help --locate-ddms-directory MUST run without error."
 }
 
 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent() {
@@ -121,8 +129,13 @@ testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput() {
     assertEquals "$(dsh --help --dsh-unit )" "$(expectedHelpFileOutput dshUnit.txt)" "dsh --help --dsh-unit output MUST match dshUnit.txt help file content."
 }
 
+testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput() {
+    assertEquals "$(dsh --help --locate-ddms-directory )" "$(expectedHelpFileOutput locateDDMSDirectory.txt)" "dsh --help --locate-ddms-directory output MUST match locateDDMSDirectory.txt help file content."
+    assertEquals "$(dsh -h -l )" "$(expectedHelpFileOutput locateDDMSDirectory.txt)" "dsh -h -l output MUST match locateDDMSDirectory.txt h file content."
+}
+
 runTest testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid 3
-runTest testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid 31
+runTest testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid 34
 runTest testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent
 runTest testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent
 runTest testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput
@@ -139,4 +152,4 @@ runTest testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalRespons
 runTest testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput
 runTest testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput
 runTest testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput
-
+runTest testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput 2

--- a/dsh/Tests/newAppTests.sh
+++ b/dsh/Tests/newAppTests.sh
@@ -86,6 +86,27 @@ testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFile
     [[ -d "$(determineAppsDirectoryPath "${random_app_name}")" ]] && rm -R "$(determineAppsDirectoryPath "${random_app_name}")"
 }
 
+actualDomain() {
+    local test_app_name
+    test_app_name="${1}"
+    printf "%s" "$(grep -o "http.*[']" "$(dsh -l)/Apps/${test_app_name}/Components.php" | sed "s/'//g")"
+}
+
+testDshNewAppAssignsSpecifiedDOMAINAsNewAppsDefaultDomainIfDOMAINIsSpecified() {
+     local test_app_name expected_domain
+     test_app_name="App${RANDOM}"
+     expected_domain="http://testdomain${RANDOM}.example/"
+     dsh -n App "${test_app_name}" "${expected_domain}"
+     assertEquals "${expected_domain}" "$(actualDomain "${test_app_name}")"
+}
+
+testDshNewAppRunsWithErrorIfSpecifiedDOMAINIsNotAValidDomain() {
+    assertError "dsh -n App AppName${RANDOM} fooBarBaz"
+    assertError "dsh -n App AppName${RANDOM} 'http:mistypedurl'"
+    assertError "dsh -n App AppName${RANDOM} 'http/:mistypedurl'"
+    assertError "dsh -n App AppName${RANDOM} 'mistypedurl.com'"
+}
+
 runTest testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified
 runTest testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME
 runTest testDshNewAppCreatesNewAppsDirectory
@@ -97,5 +118,5 @@ runTest testDshNewAppCreatesNewAppsCssDirectory
 runTest testDshNewAppCreatesNewAppsJsDirectory
 runTest testDshNewAppCreatesNewAppsComponentsPhpFile
 runTest testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate 2
-
-
+runTest testDshNewAppAssignsSpecifiedDOMAINAsNewAppsDefaultDomainIfDOMAINIsSpecified
+runTest testDshNewAppRunsWithErrorIfSpecifiedDOMAINIsNotAValidDomain 4

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -74,13 +74,9 @@ showHelpInfo() {
     if [[ "${1}" == "--new" && "${2}" == "App" ]] || [[ "${1}" == "-n" && "${2}" ==  "App" ]]; then
         showHelpFile "newApp.txt"
     fi
-
-
     if [[ "${1}" == "--new" && "${2}" == "AppPackage" ]] || [[ "${1}" == "-n" && "${2}" ==  "AppPackage" ]]; then
         showHelpFile "newAppPackage.txt"
     fi
-
-
     if [[ "${1}" == "--new" && "${2}" == "OutputComponent" ]] || [[ "${1}" == "-n" && "${2}" ==  "OutputComponent" ]]; then
         showHelpFile "newOutputComponent.txt"
     fi
@@ -104,6 +100,9 @@ showHelpInfo() {
     fi
     if [[ "${1}" == "--dsh-unit" ]] || [[ "${1}" == "-d" ]]; then
         showHelpFile "dshUnit.txt"
+    fi
+    if [[ "${1}" == "--locate-ddms-directory" ]] || [[ "${1}" == "-l" ]]; then
+        showHelpFile "locateDDMSDirectory.txt"
     fi
     logErrorMsgAndExit1 "dsh --help <FLAG> expects a valid dsh flag. Run dsh --help or man dsh for more information on how dsh works."
 }

--- a/dsh/dsh
+++ b/dsh/dsh
@@ -151,6 +151,13 @@ validateMode() {
     [[ -z "${map[${1}]}" ]] && logErrorMsg "dsh --new expects a valid mode. The following modes are available:" && logErrorMsg "$(printf '\n\e[0m\e[104m\e[30m%s\e[0m\n' "${validModes[@]}" | column)" && logErrorMsg "For more information about the dsh --new flag, use dsh --help --new" && logErrorMsgAndExit1 "For more information about a specific mode, use dsh --help --new <MODE>"
 }
 
+assignSpecifiedDomain() {
+    local regex
+    regex="(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]"
+    [[ $2 =~ $regex ]] && sed -i "s,http.*['],${2}',g"  "$(determineAppDirectoryPath "${1}")/Components.php" && notifyUser "The ${1} App was created successfully, and the domain ${2} was assigned as the defult domain." 0 'dontClear' && exit 0
+    logErrorMsgAndExit1 "Warning: The specified [DOMAIN], ${2}, does not appear to be a valid domain, http://localhost:8080/ will be used instead. To correct the domain, either edit the ${1} App's Components.php, or re-run dsh -n App ${1} [DOMAIN] and make sure [DOMAIN] is correct."
+}
+
 createNewApp() {
       [[ -z "${1}" ]] && logErrorMsg "dsh --new App <APP_NAME> <DOMAIN> expects the new App's name be specified as the first modal argument." && logErrorMsg "For example, to create an app named Foo:" && logErrorMsg "dsh --new App Foo" && logErrorMsgAndExit1 "For more information use dsh --help --new App"
       [[ -d "$(determineAppDirectoryPath "${1}")" ]] && logErrorMsgAndExit1 "An App named ${1} already exists, please specify a unique name for the new App."
@@ -179,7 +186,10 @@ createNewApp() {
       showLoadingBar "    Creating App's Components.php file at $(determineAppDirectoryPath "${1}")/Components.php" 'dontClear'
       cp "$(determineDshDirectoryPath)/FileTemplates/Components.php" "$(determineAppDirectoryPath "${1}")/Components.php"
 
-      notifyUser "The ${1} App was created successfully." 0 'dontClear'
+      if [[ -n "${2}" ]]; then
+        assignSpecifiedDomain "${1}" "${2}"
+      fi
+      notifyUser "The ${1} App was created successfully, http://localhost:8080 was assigned as the default domain." 0 'dontClear'
       exit 0
 }
 

--- a/dsh/helpFiles/locateDDMSDirectory.txt
+++ b/dsh/helpFiles/locateDDMSDirectory.txt
@@ -1,0 +1,11 @@
+
+dsh --locate-ddms-directory
+
+Description:
+Returns the path to the Darling Data Management System installation that dsh is acting on.
+
+Shorthand:
+dsh -l
+
+Example:
+dsh -l

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,20 +1,479 @@
 
 
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpRunsWithoutError     =-=-[0m
+[0m[44m[30mMon Jan 18 04:31:29 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 04:31:32 PM EST 2021 testDshHelpRunsWithoutError Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpCreatesSystemManPageForDsh     =-=-[0m
+[0m[44m[30mMon Jan 18 04:31:39 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 04:31:42 PM EST 2021 testDshHelpCreatesSystemManPageForDsh Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpOutputMatchesManDshOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:32:21 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:32:24 PM EST 2021 testDshHelpOutputMatchesManDshOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid     =-=-[0m
+[0m[44m[30mMon Jan 18 04:32:33 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 04:32:40 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 04:32:46 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:32:50 PM EST 2021 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid     =-=-[0m
+[0m[44m[30mMon Jan 18 04:32:55 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:32:58 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:01 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:05 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:08 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:11 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:14 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:18 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:21 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:25 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:28 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:31 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:35 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:38 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:41 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:44 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:47 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:50 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:53 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:56 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:33:59 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:02 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:05 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:08 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:11 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:14 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:17 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:21 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:24 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:26 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:34:29 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 04:34:33 PM EST 2021 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent     =-=-[0m
+[0m[44m[30mMon Jan 18 04:34:45 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:34:49 PM EST 2021 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent     =-=-[0m
+[0m[44m[30mMon Jan 18 04:35:14 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:35:18 PM EST 2021 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:36:06 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:36:10 PM EST 2021 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:36:24 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:36:29 PM EST 2021 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:36:49 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:36:53 PM EST 2021 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:37:13 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:37:17 PM EST 2021 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:37:44 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:37:48 PM EST 2021 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:38:14 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:38:19 PM EST 2021 testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:38:46 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:38:51 PM EST 2021 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:39:31 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:39:36 PM EST 2021 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:40:07 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:40:12 PM EST 2021 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:40:30 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:40:34 PM EST 2021 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:40:54 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:40:59 PM EST 2021 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:41:26 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:41:31 PM EST 2021 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:41:52 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:41:56 PM EST 2021 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 04:42:23 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:42:27 PM EST 2021 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerStartsADevelopmentServerWithoutError     =-=-[0m
+[0m[44m[30mMon Jan 18 04:42:34 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:42:38 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:42:42 PM EST 2021 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:42:50 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:42:54 PM EST 2021 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:43:02 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:43:06 PM EST 2021 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:43:15 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:43:19 PM EST 2021 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 04:43:30 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:43:34 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 04:44:05 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:44:09 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 04:44:36 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 04:44:41 PM EST 2021 testDshBuildAppBuildsSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:45:13 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:45:20 PM EST 2021 testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:45:48 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:45:54 PM EST 2021 testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:46:03 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:46:06 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotValid     =-=-[0m
+[0m[44m[30mMon Jan 18 04:46:21 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:46:24 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotValid Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:46:36 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:46:39 PM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME     =-=-[0m
+[0m[44m[30mMon Jan 18 04:47:02 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:47:06 PM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:47:25 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:47:28 PM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsOutputComponentsDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:47:48 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:47:51 PM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsRequestsDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:48:11 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:48:14 PM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsResponsesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:48:33 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:48:37 PM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDynamicOutputDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:48:56 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:49:00 PM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsCssDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:49:19 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:49:22 PM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsJsDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 04:49:41 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 04:49:44 PM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFile     =-=-[0m
+[0m[44m[30mMon Jan 18 04:50:04 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 04:50:07 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate     =-=-[0m
+[0m[44m[30mMon Jan 18 04:50:28 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 04:50:53 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:50:58 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:51:22 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:51:25 PM EST 2021 testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 04:51:39 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:51:43 PM EST 2021 testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
+[0m[44m[30mMon Jan 18 04:52:05 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:52:10 PM EST 2021 testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:52:20 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:52:24 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:52:35 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:52:39 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:52:50 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:52:54 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:53:05 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:53:09 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 04:53:26 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 04:53:30 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 04:53:46 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:53:52 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:54:16 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:54:20 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 04:54:35 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:54:39 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
+[0m[44m[30mMon Jan 18 04:55:03 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:55:09 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:55:20 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:55:25 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:55:37 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:55:42 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:55:54 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:55:58 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:56:10 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:56:14 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 04:56:32 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 04:56:37 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 04:56:54 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:56:59 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:57:22 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:57:26 PM EST 2021 testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 04:57:38 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:57:42 PM EST 2021 testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists     =-=-[0m
+[0m[44m[30mMon Jan 18 04:58:02 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:58:06 PM EST 2021 testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:58:15 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:58:19 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:58:29 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:58:32 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:58:42 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:58:46 PM EST 2021 testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 04:59:02 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 04:59:05 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 04:59:22 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 04:59:26 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 04:59:49 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 04:59:53 PM EST 2021 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 05:00:05 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:00:09 PM EST 2021 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists     =-=-[0m
+[0m[44m[30mMon Jan 18 05:00:29 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:00:33 PM EST 2021 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:00:42 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:00:46 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:00:55 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:00:59 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 05:01:15 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:01:19 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 05:01:38 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:01:43 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:02:06 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:02:10 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 05:02:23 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:02:26 PM EST 2021 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists     =-=-[0m
+[0m[44m[30mMon Jan 18 05:02:48 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:02:53 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:03:03 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:03:07 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:03:17 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:03:21 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 05:03:38 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:03:43 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 05:04:01 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:04:06 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:04:14 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:04:18 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:04:28 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:04:32 PM EST 2021 testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE     =-=-[0m
+[0m[44m[30mMon Jan 18 05:04:40 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:04:45 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE     =-=-[0m
+[0m[44m[30mMon Jan 18 05:04:54 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:04:58 PM EST 2021 testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName     =-=-[0m
+[0m[44m[30mMon Jan 18 05:05:13 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 05:05:18 PM EST 2021 testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:05:32 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 05:05:37 PM EST 2021 testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:05:51 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 05:05:55 PM EST 2021 testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:06:09 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 05:06:14 PM EST 2021 testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:06:28 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:06:32 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 05:07:11 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:07:16 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:07:31 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:07:35 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 05:08:18 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:08:23 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:08:38 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:08:42 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 05:09:33 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:09:38 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory     =-=-[0m
+[0m[44m[30mMon Jan 18 05:09:53 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:09:56 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
+[0m[44m[30mMon Jan 18 05:10:23 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:10:28 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:10:59 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:11:03 PM EST 2021 testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:11:13 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:11:17 PM EST 2021 testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:11:27 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:11:31 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:11:42 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:11:46 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified     =-=-[0m
+[0m[44m[30mMon Jan 18 05:11:56 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:12:00 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
+[0m[44m[30mMon Jan 18 05:12:12 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:12:16 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 05:12:28 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:12:33 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp     =-=-[0m
+[0m[44m[30mMon Jan 18 05:12:44 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 05:12:53 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 05:13:01 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:13:05 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseProducesExpectedResponseConfiguration     =-=-[0m
+[0m[44m[30mMon Jan 18 05:13:39 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:13:43 PM EST 2021 testDshAssignToResponseProducesExpectedResponseConfiguration Passed[0m
+
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryRunsWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 04:11:09 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:11:11 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 04:11:14 PM EST 2021 testDshLocateDDMSDirectoryRunsWithoutError Passed[0m
+[0m[44m[30mMon Jan 18 05:13:48 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:13:50 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 05:13:53 PM EST 2021 testDshLocateDDMSDirectoryRunsWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryReturnsExpectedPath     =-=-[0m
-[0m[44m[30mMon Jan 18 04:11:20 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:11:23 PM EST 2021 testDshLocateDDMSDirectoryReturnsExpectedPath Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryRunsWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 04:12:23 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:12:25 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 04:12:29 PM EST 2021 testDshLocateDDMSDirectoryRunsWithoutError Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryReturnsExpectedPath     =-=-[0m
-[0m[44m[30mMon Jan 18 04:12:34 PM EST 2021 assertEquals Passed[0m
-[0m[44m[30mMon Jan 18 04:12:37 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:12:41 PM EST 2021 testDshLocateDDMSDirectoryReturnsExpectedPath Passed[0m
+[0m[44m[30mMon Jan 18 05:13:59 PM EST 2021 assertEquals Passed[0m
+[0m[44m[30mMon Jan 18 05:14:03 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:14:06 PM EST 2021 testDshLocateDDMSDirectoryReturnsExpectedPath Passed[0m

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,479 +1,487 @@
 
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpRunsWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 04:31:29 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 04:31:32 PM EST 2021 testDshHelpRunsWithoutError Passed[0m
+[0m[44m[30mMon Jan 18 05:55:44 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 05:55:47 PM EST 2021 testDshHelpRunsWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpCreatesSystemManPageForDsh     =-=-[0m
-[0m[44m[30mMon Jan 18 04:31:39 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 04:31:42 PM EST 2021 testDshHelpCreatesSystemManPageForDsh Passed[0m
+[0m[44m[30mMon Jan 18 05:55:53 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 05:55:56 PM EST 2021 testDshHelpCreatesSystemManPageForDsh Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpOutputMatchesManDshOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:32:21 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:32:24 PM EST 2021 testDshHelpOutputMatchesManDshOutput Passed[0m
+[0m[44m[30mMon Jan 18 05:56:37 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:56:40 PM EST 2021 testDshHelpOutputMatchesManDshOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid     =-=-[0m
-[0m[44m[30mMon Jan 18 04:32:33 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 04:32:40 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 04:32:46 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:32:50 PM EST 2021 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
+[0m[44m[30mMon Jan 18 05:56:49 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 05:56:55 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:02 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 05:57:06 PM EST 2021 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid     =-=-[0m
-[0m[44m[30mMon Jan 18 04:32:55 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:32:58 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:01 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:05 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:08 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:11 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:14 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:18 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:21 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:25 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:28 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:31 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:35 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:38 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:41 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:44 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:47 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:50 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:53 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:56 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:33:59 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:02 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:05 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:08 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:11 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:14 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:17 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:21 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:24 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:26 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:34:29 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 04:34:33 PM EST 2021 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
+[0m[44m[30mMon Jan 18 05:57:11 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:14 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:17 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:21 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:24 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:27 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:30 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:34 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:37 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:41 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:44 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:47 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:51 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:54 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:57:58 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:01 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:04 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:07 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:10 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:13 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:16 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:19 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:22 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:25 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:28 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:32 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:35 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:38 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:42 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:45 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:48 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:51 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:54 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 05:58:57 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 05:59:01 PM EST 2021 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent     =-=-[0m
-[0m[44m[30mMon Jan 18 04:34:45 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:34:49 PM EST 2021 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
+[0m[44m[30mMon Jan 18 05:59:13 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:59:17 PM EST 2021 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent     =-=-[0m
-[0m[44m[30mMon Jan 18 04:35:14 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:35:18 PM EST 2021 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
+[0m[44m[30mMon Jan 18 05:59:43 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 05:59:47 PM EST 2021 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:36:06 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:36:10 PM EST 2021 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:00:37 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:00:41 PM EST 2021 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:36:24 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:36:29 PM EST 2021 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:00:55 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:01:00 PM EST 2021 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:36:49 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:36:53 PM EST 2021 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:01:21 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:01:25 PM EST 2021 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:37:13 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:37:17 PM EST 2021 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:01:46 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:01:49 PM EST 2021 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:37:44 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:37:48 PM EST 2021 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:02:18 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:02:22 PM EST 2021 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:38:14 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:38:19 PM EST 2021 testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:02:49 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:02:54 PM EST 2021 testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:38:46 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:38:51 PM EST 2021 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:03:22 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:03:27 PM EST 2021 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:39:31 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:39:36 PM EST 2021 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:04:08 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:04:13 PM EST 2021 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:40:07 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:40:12 PM EST 2021 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:04:46 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:04:50 PM EST 2021 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:40:30 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:40:34 PM EST 2021 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:05:09 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:05:13 PM EST 2021 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:40:54 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:40:59 PM EST 2021 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:05:33 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:05:38 PM EST 2021 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:41:26 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:41:31 PM EST 2021 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:06:06 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:06:10 PM EST 2021 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:41:52 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:41:56 PM EST 2021 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:06:32 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:06:36 PM EST 2021 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 04:42:23 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:42:27 PM EST 2021 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m
+[0m[44m[30mMon Jan 18 06:07:04 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:07:08 PM EST 2021 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput     =-=-[0m
+[0m[44m[30mMon Jan 18 06:07:18 PM EST 2021 assertEquals Passed[0m
+[0m[44m[30mMon Jan 18 06:07:26 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:07:31 PM EST 2021 testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerStartsADevelopmentServerWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 04:42:34 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:42:38 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:42:42 PM EST 2021 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
+[0m[44m[30mMon Jan 18 06:07:38 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 06:07:41 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:07:45 PM EST 2021 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:42:50 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:42:54 PM EST 2021 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:07:54 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:07:58 PM EST 2021 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:43:02 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:43:06 PM EST 2021 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:08:06 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:08:10 PM EST 2021 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:43:15 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:43:19 PM EST 2021 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:08:19 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:08:23 PM EST 2021 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 04:43:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:43:34 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:08:34 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:08:37 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 04:44:05 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:44:09 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:09:01 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:09:05 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 04:44:36 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 04:44:41 PM EST 2021 testDshBuildAppBuildsSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:09:32 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 06:09:37 PM EST 2021 testDshBuildAppBuildsSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:45:13 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:45:20 PM EST 2021 testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:10:10 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:10:16 PM EST 2021 testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:45:48 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:45:54 PM EST 2021 testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:10:45 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:10:51 PM EST 2021 testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:46:03 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:46:06 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:11:00 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:11:03 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotValid     =-=-[0m
-[0m[44m[30mMon Jan 18 04:46:21 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:46:24 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotValid Passed[0m
+[0m[44m[30mMon Jan 18 06:11:18 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:11:21 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotValid Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:46:36 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:46:39 PM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:11:33 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:11:36 PM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME     =-=-[0m
-[0m[44m[30mMon Jan 18 04:47:02 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:47:06 PM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
+[0m[44m[30mMon Jan 18 06:12:00 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:12:03 PM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:47:25 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:47:28 PM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:12:23 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:12:26 PM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsOutputComponentsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:47:48 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:47:51 PM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:12:46 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:12:50 PM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsRequestsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:48:11 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:48:14 PM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:13:09 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:13:13 PM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsResponsesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:48:33 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:48:37 PM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:13:33 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:13:36 PM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDynamicOutputDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:48:56 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:49:00 PM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:13:56 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:14:00 PM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsCssDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:49:19 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:49:22 PM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:14:19 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:14:22 PM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsJsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 04:49:41 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 04:49:44 PM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:14:42 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:14:45 PM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFile     =-=-[0m
-[0m[44m[30mMon Jan 18 04:50:04 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 04:50:07 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
+[0m[44m[30mMon Jan 18 06:15:05 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:15:08 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate     =-=-[0m
-[0m[44m[30mMon Jan 18 04:50:28 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 04:50:53 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:50:58 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
+[0m[44m[30mMon Jan 18 06:15:29 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 06:15:56 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:16:01 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:51:22 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:51:25 PM EST 2021 testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:16:25 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:16:29 PM EST 2021 testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 04:51:39 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:51:43 PM EST 2021 testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:16:42 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:16:46 PM EST 2021 testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 04:52:05 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:52:10 PM EST 2021 testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
+[0m[44m[30mMon Jan 18 06:17:09 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:17:14 PM EST 2021 testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:52:20 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:52:24 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:17:24 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:17:28 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:52:35 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:52:39 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:17:39 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:17:44 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:52:50 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:52:54 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:17:55 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:17:59 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:53:05 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:53:09 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:18:10 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:18:13 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 04:53:26 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 04:53:30 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:18:31 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:18:35 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 04:53:46 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:53:52 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:18:52 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:18:57 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:54:16 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:54:20 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:19:22 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:19:26 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 04:54:35 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:54:39 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:19:41 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:19:45 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 04:55:03 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:55:09 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
+[0m[44m[30mMon Jan 18 06:20:10 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:20:16 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:55:20 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:55:25 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:20:27 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:20:32 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:55:37 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:55:42 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:20:44 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:20:49 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:55:54 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:55:58 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:21:01 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:21:06 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:56:10 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:56:14 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:21:17 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:21:21 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 04:56:32 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 04:56:37 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:21:40 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:21:45 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 04:56:54 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:56:59 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:22:02 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:22:08 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:57:22 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:57:26 PM EST 2021 testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:22:31 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:22:34 PM EST 2021 testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 04:57:38 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:57:42 PM EST 2021 testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:22:47 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:22:51 PM EST 2021 testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 04:58:02 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:58:06 PM EST 2021 testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists Passed[0m
+[0m[44m[30mMon Jan 18 06:23:11 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:23:15 PM EST 2021 testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:58:15 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:58:19 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:23:24 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:23:28 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:58:29 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:58:32 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:23:38 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:23:42 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:58:42 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:58:46 PM EST 2021 testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:23:52 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:23:55 PM EST 2021 testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 04:59:02 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 04:59:05 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:24:11 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:24:15 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 04:59:22 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 04:59:26 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:24:31 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:24:36 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 04:59:49 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 04:59:53 PM EST 2021 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:24:59 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:25:03 PM EST 2021 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 05:00:05 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:00:09 PM EST 2021 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:25:16 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:25:19 PM EST 2021 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 05:00:29 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:00:33 PM EST 2021 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
+[0m[44m[30mMon Jan 18 06:25:39 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:25:43 PM EST 2021 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:00:42 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:00:46 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:25:53 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:25:57 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:00:55 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:00:59 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:26:06 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:26:10 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 05:01:15 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:01:19 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:26:26 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:26:30 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:01:38 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:01:43 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:26:49 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:26:54 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:02:06 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:02:10 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:27:18 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:27:21 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 05:02:23 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:02:26 PM EST 2021 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:27:35 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:27:38 PM EST 2021 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 05:02:48 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:02:53 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
+[0m[44m[30mMon Jan 18 06:28:00 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:28:05 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:03:03 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:03:07 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:28:15 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:28:19 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:03:17 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:03:21 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:28:30 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:28:34 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 05:03:38 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:03:43 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:28:51 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:28:56 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:04:01 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:04:06 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:29:14 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:29:19 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:04:14 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:04:18 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:29:28 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:29:31 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:04:28 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:04:32 PM EST 2021 testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:29:41 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:29:45 PM EST 2021 testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE     =-=-[0m
-[0m[44m[30mMon Jan 18 05:04:40 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:04:45 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
+[0m[44m[30mMon Jan 18 06:29:54 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:29:58 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE     =-=-[0m
-[0m[44m[30mMon Jan 18 05:04:54 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:04:58 PM EST 2021 testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
+[0m[44m[30mMon Jan 18 06:30:07 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:30:12 PM EST 2021 testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName     =-=-[0m
-[0m[44m[30mMon Jan 18 05:05:13 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 05:05:18 PM EST 2021 testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName Passed[0m
+[0m[44m[30mMon Jan 18 06:30:27 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:30:32 PM EST 2021 testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:05:32 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 05:05:37 PM EST 2021 testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:30:46 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:30:50 PM EST 2021 testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:05:51 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 05:05:55 PM EST 2021 testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:31:05 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:31:09 PM EST 2021 testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:06:09 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 05:06:14 PM EST 2021 testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:31:24 PM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mMon Jan 18 06:31:28 PM EST 2021 testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:06:28 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:06:32 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:31:42 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:31:46 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:07:11 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:07:16 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:32:26 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:32:31 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:07:31 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:07:35 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:32:46 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:32:50 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:08:18 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:08:23 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:33:35 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:33:40 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:08:38 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:08:42 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:33:54 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:33:58 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:09:33 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:09:38 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:34:50 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:34:55 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 05:09:53 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:09:56 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory Passed[0m
+[0m[44m[30mMon Jan 18 06:35:10 PM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mMon Jan 18 06:35:14 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:10:23 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:10:28 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
+[0m[44m[30mMon Jan 18 06:35:40 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:35:45 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:10:59 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:11:03 PM EST 2021 testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:36:17 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:36:20 PM EST 2021 testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:11:13 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:11:17 PM EST 2021 testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:36:30 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:36:34 PM EST 2021 testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:11:27 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:11:31 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:36:45 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:36:49 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:11:42 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:11:46 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:36:59 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:37:04 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 05:11:56 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:12:00 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified Passed[0m
+[0m[44m[30mMon Jan 18 06:37:14 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:37:18 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 05:12:12 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:12:16 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
+[0m[44m[30mMon Jan 18 06:37:30 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:37:34 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 05:12:28 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:12:33 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:37:47 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:37:51 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 05:12:44 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 05:12:53 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 05:13:01 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:13:05 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp Passed[0m
+[0m[44m[30mMon Jan 18 06:38:02 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 06:38:11 PM EST 2021 assertError Passed[0m
+[0m[44m[30mMon Jan 18 06:38:19 PM EST 2021 assertError Passed[0m
+[0m[104m[30mMon Jan 18 06:38:24 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseProducesExpectedResponseConfiguration     =-=-[0m
-[0m[44m[30mMon Jan 18 05:13:39 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:13:43 PM EST 2021 testDshAssignToResponseProducesExpectedResponseConfiguration Passed[0m
+[0m[44m[30mMon Jan 18 06:38:58 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:39:02 PM EST 2021 testDshAssignToResponseProducesExpectedResponseConfiguration Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryRunsWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 05:13:48 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:13:50 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 05:13:53 PM EST 2021 testDshLocateDDMSDirectoryRunsWithoutError Passed[0m
+[0m[44m[30mMon Jan 18 06:39:07 PM EST 2021 assertNoError Passed[0m
+[0m[44m[30mMon Jan 18 06:39:09 PM EST 2021 assertNoError Passed[0m
+[0m[104m[30mMon Jan 18 06:39:12 PM EST 2021 testDshLocateDDMSDirectoryRunsWithoutError Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryReturnsExpectedPath     =-=-[0m
-[0m[44m[30mMon Jan 18 05:13:59 PM EST 2021 assertEquals Passed[0m
-[0m[44m[30mMon Jan 18 05:14:03 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:14:06 PM EST 2021 testDshLocateDDMSDirectoryReturnsExpectedPath Passed[0m
+[0m[44m[30mMon Jan 18 06:39:18 PM EST 2021 assertEquals Passed[0m
+[0m[44m[30mMon Jan 18 06:39:22 PM EST 2021 assertEquals Passed[0m
+[0m[104m[30mMon Jan 18 06:39:25 PM EST 2021 testDshLocateDDMSDirectoryReturnsExpectedPath Passed[0m

--- a/dshUnit/dshUnitTests.log
+++ b/dshUnit/dshUnitTests.log
@@ -1,487 +1,57 @@
 
 
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpRunsWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 05:55:44 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 05:55:47 PM EST 2021 testDshHelpRunsWithoutError Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpCreatesSystemManPageForDsh     =-=-[0m
-[0m[44m[30mMon Jan 18 05:55:53 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 05:55:56 PM EST 2021 testDshHelpCreatesSystemManPageForDsh Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpOutputMatchesManDshOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 05:56:37 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:56:40 PM EST 2021 testDshHelpOutputMatchesManDshOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid     =-=-[0m
-[0m[44m[30mMon Jan 18 05:56:49 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 05:56:55 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:02 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 05:57:06 PM EST 2021 testDshHelpFLAGRunsWithAnErrorIfSpecifiedFlagIsNotValid Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid     =-=-[0m
-[0m[44m[30mMon Jan 18 05:57:11 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:14 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:17 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:21 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:24 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:27 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:30 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:34 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:37 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:41 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:44 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:47 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:51 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:54 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:57:58 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:01 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:04 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:07 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:10 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:13 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:16 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:19 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:22 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:25 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:28 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:32 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:35 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:38 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:42 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:45 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:48 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:51 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:54 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 05:58:57 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 05:59:01 PM EST 2021 testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:59:13 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:59:17 PM EST 2021 testDshHelpHelpOutputMatchesDshUIColorized_Help_HelpFileContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent     =-=-[0m
-[0m[44m[30mMon Jan 18 05:59:43 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 05:59:47 PM EST 2021 testDshHelpFLAGOutputMatchesDshUIColorized_HelpFLAG_HelpFileContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:00:37 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:00:41 PM EST 2021 testDshHelpFlagsOutputMatchesDshUIColorized_HelpFlags_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:00:55 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:01:00 PM EST 2021 testDshHelpStartDevelopmentServerOutputMatchesDshUIColorized_StartDevelopmentServer_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:01:21 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:01:25 PM EST 2021 testDshHelpBuildAppOutputMatchesDshUIColorized_BuildApp_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:01:46 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:01:49 PM EST 2021 testDshHelpNewOutputMatchesDshUIColorized_New_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:02:18 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:02:22 PM EST 2021 testDshHelpNewAppOutputMatchesDshUIColorized_NewApp_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:02:49 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:02:54 PM EST 2021 testDshHelpNewAppPackageOutputMatchesDshUIColorized_NewAppPackage_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:03:22 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:03:27 PM EST 2021 testDshHelpNewOutputComponentOutputMatchesDshUIColorized_NewOutputComponent_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:04:08 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:04:13 PM EST 2021 testDshHelpNewDynamicOutputComponentOutputMatchesDshUIColorized_NewDynamicOutputComponent_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:04:46 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:04:50 PM EST 2021 testDshHelpNewRequestOutputMatchesDshUIColorized_NewRequest_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:05:09 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:05:13 PM EST 2021 testDshHelpNewResponseOutputMatchesDshUIColorized_NewResponse_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:05:33 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:05:38 PM EST 2021 testDshHelpNewGlobalResponseOutputMatchesDshUIColorized_NewGlobalResponse_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:06:06 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:06:10 PM EST 2021 testDshHelpAssignToResponseOutputMatchesDshUIColorized_AssignToResponse_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:06:32 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:06:36 PM EST 2021 testDshHelpPhpUnitOutputMatchesDshUIColorized_PhpUnit_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:07:04 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:07:08 PM EST 2021 testDshHelpDshUnitOutputMatchesDshUIColorized_DshUnit_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput     =-=-[0m
-[0m[44m[30mMon Jan 18 06:07:18 PM EST 2021 assertEquals Passed[0m
-[0m[44m[30mMon Jan 18 06:07:26 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:07:31 PM EST 2021 testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerStartsADevelopmentServerWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 06:07:38 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 06:07:41 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:07:45 PM EST 2021 testDshStartDevelopmentServerStartsADevelopmentServerWithoutError Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:07:54 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:07:58 PM EST 2021 testDshStartDevelopmentServerUsesPort8080IfPORTIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:08:06 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:08:10 PM EST 2021 testDshStartDevelopmentServerUsesSpecifiedPORTIfPORTIsSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:08:19 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:08:23 PM EST 2021 testDshBuildAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:08:34 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:08:37 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsDirectoryDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:09:01 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:09:05 PM EST 2021 testDshBuildAppRunsWithErrorIfSpecifiedAppsComponentsPhpFileDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:09:32 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 06:09:37 PM EST 2021 testDshBuildAppBuildsSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:10:10 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:10:16 PM EST 2021 testDshBuildAppBuildsAppForDomainLocalhost8080IfDomainIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:10:45 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:10:51 PM EST 2021 testDshBuildAppBuildsAppForSpecifiedDomainIfDomainIsSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:11:00 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:11:03 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewRunsWithErrorIfMODEIsNotValid     =-=-[0m
-[0m[44m[30mMon Jan 18 06:11:18 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:11:21 PM EST 2021 testDshNewRunsWithErrorIfMODEIsNotValid Passed[0m
-
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:11:33 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:11:36 PM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
+[0m[44m[30mTue Jan 19 01:01:22 AM EST 2021 assertError Passed[0m
+[0m[104m[30mTue Jan 19 01:01:25 AM EST 2021 testDshNewAppRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME     =-=-[0m
-[0m[44m[30mMon Jan 18 06:12:00 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:12:03 PM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
+[0m[44m[30mTue Jan 19 01:02:00 AM EST 2021 assertError Passed[0m
+[0m[104m[30mTue Jan 19 01:02:04 AM EST 2021 testDshNewAppRunsWithErrorIfAnAppAlreadyExistsNamedAPP_NAME Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:12:23 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:12:26 PM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:02:34 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:02:37 AM EST 2021 testDshNewAppCreatesNewAppsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsOutputComponentsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:12:46 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:12:50 PM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:03:07 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:03:11 AM EST 2021 testDshNewAppCreatesNewAppsOutputComponentsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsRequestsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:13:09 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:13:13 PM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:03:41 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:03:44 AM EST 2021 testDshNewAppCreatesNewAppsRequestsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsResponsesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:13:33 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:13:36 PM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:04:14 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:04:18 AM EST 2021 testDshNewAppCreatesNewAppsResponsesDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsDynamicOutputDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:13:56 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:14:00 PM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:04:48 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:04:52 AM EST 2021 testDshNewAppCreatesNewAppsDynamicOutputDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsCssDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:14:19 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:14:22 PM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:05:22 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:05:25 AM EST 2021 testDshNewAppCreatesNewAppsCssDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsJsDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:14:42 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:14:45 PM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
+[0m[44m[30mTue Jan 19 01:05:55 AM EST 2021 assertDirectoryExists Passed[0m
+[0m[104m[30mTue Jan 19 01:05:58 AM EST 2021 testDshNewAppCreatesNewAppsJsDirectory Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFile     =-=-[0m
-[0m[44m[30mMon Jan 18 06:15:05 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:15:08 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
+[0m[44m[30mTue Jan 19 01:06:28 AM EST 2021 assertFileExists Passed[0m
+[0m[104m[30mTue Jan 19 01:06:31 AM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFile Passed[0m
 
 [0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate     =-=-[0m
-[0m[44m[30mMon Jan 18 06:15:29 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 06:15:56 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:16:01 PM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:16:25 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:16:29 PM EST 2021 testNewOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:16:42 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:16:46 PM EST 2021 testNewOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 06:17:09 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:17:14 PM EST 2021 testNewOutputComponentRunsWithErrorIfAnOutputComponentNamedOUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:17:24 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:17:28 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:17:39 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:17:44 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:17:55 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:17:59 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:18:10 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:18:13 PM EST 2021 testNewOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:18:31 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:18:35 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:18:52 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:18:57 PM EST 2021 testNewOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:19:22 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:19:26 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:19:41 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:19:45 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 06:20:10 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:20:16 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfAnDynamicOutputComponentNamedDYNAMIC_OUTPUT_COMPONENT_NAMEAlreadyExists Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:20:27 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:20:32 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:20:44 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:20:49 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_CONTAINERIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:21:01 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:21:06 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfDYNAMIC_OUTPUT_COMPONENT_POSITIONIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:21:17 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:21:21 PM EST 2021 testNewDynamicOutputComponentRunsWithErrorIfOUTPUTIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:21:40 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:21:45 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:22:02 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:22:08 PM EST 2021 testNewDynamicOutputComponentCreatesNewOutputComponentConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:22:31 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:22:34 PM EST 2021 testNewRequestRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:22:47 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:22:51 PM EST 2021 testNewRequestRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 06:23:11 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:23:15 PM EST 2021 testNewRequestRunsWithErrorIfAnRequestNamedREQUEST_NAMEAlreadyExists Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:23:24 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:23:28 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:23:38 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:23:42 PM EST 2021 testNewRequestRunsWithErrorIfREQUEST_CONTAINERIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:23:52 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:23:55 PM EST 2021 testNewRequestRunsWithErrorIfRELATIVE_URLIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:24:11 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:24:15 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:24:31 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:24:36 PM EST 2021 testNewRequestCreatesNewRequestConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:24:59 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:25:03 PM EST 2021 testNewResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:25:16 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:25:19 PM EST 2021 testNewResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 06:25:39 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:25:43 PM EST 2021 testNewResponseRunsWithErrorIfAnResponseNamedRESPONSE_NAMEAlreadyExists Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:25:53 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:25:57 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:26:06 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:26:10 PM EST 2021 testNewResponseRunsWithErrorIfRESPONSE_POSITIONIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:26:26 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:26:30 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:26:49 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:26:54 PM EST 2021 testNewResponseCreatesNewResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:27:18 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:27:21 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:27:35 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:27:38 PM EST 2021 testNewGlobalResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists     =-=-[0m
-[0m[44m[30mMon Jan 18 06:28:00 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:28:05 PM EST 2021 testNewGlobalResponseRunsWithErrorIfAnGlobalResponseNamedGLOBAL_RESPONSE_NAMEAlreadyExists Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:28:15 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:28:19 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:28:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:28:34 PM EST 2021 testNewGlobalResponseRunsWithErrorIfGLOBAL_RESPONSE_POSITIONIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:28:51 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:28:56 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:29:14 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:29:19 PM EST 2021 testNewGlobalResponseCreatesNewGlobalResponseConfigurationFileForSpecifiedAppWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:29:28 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:29:31 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAPP_NAMEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:29:41 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:29:45 PM EST 2021 testDshNewAppPackageRunsWithErrorIfPATH_TO_APP_PACKAGEIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE     =-=-[0m
-[0m[44m[30mMon Jan 18 06:29:54 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:29:58 PM EST 2021 testDshNewAppPackageRunsWithErrorIfAFileExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE     =-=-[0m
-[0m[44m[30mMon Jan 18 06:30:07 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:30:12 PM EST 2021 testDshNewAppPackageRunsWithErrorIfADirectoryExistsAtPATH_TO_NEW_APP_PACKAGE Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName     =-=-[0m
-[0m[44m[30mMon Jan 18 06:30:27 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:30:32 PM EST 2021 testDshNewAppPackageCreatesADirectoryForTheTheNewAppPackageAtPATH_TO_NEW_APP_PACKAGEForwardSlashAppName Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:30:46 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:30:50 PM EST 2021 testDshNewAppPackageCreatesCssDirectoryInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:31:05 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:31:09 PM EST 2021 testDshNewAppPackageCreatesJsDirectoryInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:31:24 PM EST 2021 assertDirectoryExists Passed[0m
-[0m[104m[30mMon Jan 18 06:31:28 PM EST 2021 testDshNewAppPackageCreatesDynamicOutputDirectoryInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:31:42 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:31:46 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:32:26 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:32:31 PM EST 2021 testDshNewAppPackageCreatesResponsesSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:32:46 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:32:50 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:33:35 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:33:40 PM EST 2021 testDshNewAppPackageCreatesRequestsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:33:54 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:33:58 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:34:50 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:34:55 PM EST 2021 testDshNewAppPackageCreatesOutputComponentsSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory     =-=-[0m
-[0m[44m[30mMon Jan 18 06:35:10 PM EST 2021 assertFileExists Passed[0m
-[0m[104m[30mMon Jan 18 06:35:14 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectory Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent     =-=-[0m
-[0m[44m[30mMon Jan 18 06:35:40 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:35:45 PM EST 2021 testDshNewAppPackageCreatesConfigSHInTheNewAppPackagesDirectoryWhoseContentMatchesExpectedContent Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:36:17 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:36:20 PM EST 2021 testDshAssignToResponseRunsWithErrorIfAppNameIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:36:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:36:34 PM EST 2021 testDshAssignToResponseRunsWithErrorIfResponseNameIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:36:45 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:36:49 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentNameIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:36:59 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:37:04 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentContainerIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified     =-=-[0m
-[0m[44m[30mMon Jan 18 06:37:14 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:37:18 PM EST 2021 testDshAssignToResponseRunsWithErrorIfComponentTypeIsNotSpecified Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist     =-=-[0m
-[0m[44m[30mMon Jan 18 06:37:30 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:37:34 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedAppDoesNotExist Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:37:47 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:37:51 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedResponseIsNotDefinedForSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp     =-=-[0m
-[0m[44m[30mMon Jan 18 06:38:02 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 06:38:11 PM EST 2021 assertError Passed[0m
-[0m[44m[30mMon Jan 18 06:38:19 PM EST 2021 assertError Passed[0m
-[0m[104m[30mMon Jan 18 06:38:24 PM EST 2021 testDshAssignToResponseRunsWithErrorIfSpecifiedComponentIsNotDefinedForTheSpecifiedApp Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshAssignToResponseProducesExpectedResponseConfiguration     =-=-[0m
-[0m[44m[30mMon Jan 18 06:38:58 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:39:02 PM EST 2021 testDshAssignToResponseProducesExpectedResponseConfiguration Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryRunsWithoutError     =-=-[0m
-[0m[44m[30mMon Jan 18 06:39:07 PM EST 2021 assertNoError Passed[0m
-[0m[44m[30mMon Jan 18 06:39:09 PM EST 2021 assertNoError Passed[0m
-[0m[104m[30mMon Jan 18 06:39:12 PM EST 2021 testDshLocateDDMSDirectoryRunsWithoutError Passed[0m
-
-[0m[44m[30m[0m[7m[90m-=-=     Running testDshLocateDDMSDirectoryReturnsExpectedPath     =-=-[0m
-[0m[44m[30mMon Jan 18 06:39:18 PM EST 2021 assertEquals Passed[0m
-[0m[44m[30mMon Jan 18 06:39:22 PM EST 2021 assertEquals Passed[0m
-[0m[104m[30mMon Jan 18 06:39:25 PM EST 2021 testDshLocateDDMSDirectoryReturnsExpectedPath Passed[0m
+[0m[44m[30mTue Jan 19 01:07:03 AM EST 2021 assertNoError Passed[0m
+[0m[44m[30mTue Jan 19 01:07:29 AM EST 2021 assertEquals Passed[0m
+[0m[104m[30mTue Jan 19 01:07:34 AM EST 2021 testDshNewAppCreatesNewAppsComponentsPhpFileWhoseContentMatchesComponentsPhpFileTemplate Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppAssignsSpecifiedDOMAINAsNewAppsDefaultDomainIfDOMAINIsSpecified     =-=-[0m
+[0m[44m[30mTue Jan 19 01:08:02 AM EST 2021 assertEquals Passed[0m
+[0m[104m[30mTue Jan 19 01:08:06 AM EST 2021 testDshNewAppAssignsSpecifiedDOMAINAsNewAppsDefaultDomainIfDOMAINIsSpecified Passed[0m
+
+[0m[44m[30m[0m[7m[90m-=-=     Running testDshNewAppRunsWithErrorIfSpecifiedDOMAINIsNotAValidDomain     =-=-[0m
+[0m[44m[30mTue Jan 19 01:08:38 AM EST 2021 assertError Passed[0m
+[0m[44m[30mTue Jan 19 01:09:08 AM EST 2021 assertError Passed[0m
+[0m[44m[30mTue Jan 19 01:09:38 AM EST 2021 assertError Passed[0m
+[0m[44m[30mTue Jan 19 01:10:08 AM EST 2021 assertError Passed[0m
+[0m[104m[30mTue Jan 19 01:10:12 AM EST 2021 testDshNewAppRunsWithErrorIfSpecifiedDOMAINIsNotAValidDomain Passed[0m


### PR DESCRIPTION
DSH: Refactored `dsh/Tests/helpFLAGTests.sh`. Added the following new assertions to `testDshHelpFLAGRunsWithoutErrorIfSpecifiedFlagIsValid()`:

```
assertNoError "dsh --help --locate-ddms-directory" "dsh --help --locate-ddms-directory MUST run without error."
assertNoError "dsh -h -n AppPackage" "dsh -h -n AppPackage MUST run without error."
assertNoError "dsh -h -l" "dsh --help --locate-ddms-directory MUST run without error."
```

Implemented new test in `dsh/Tests/helpFLAGTests.sh`:

`testDshHelpLocateDDMSDirectoryOutputMatchesDshUIColorized_LocateDDMSDirectory_HelpFileOutput()`

All **dsh** tests are passing.

This is related to closed issue #100.

DSH: Refactored `dsh/Tests/newAppTests.sh`. Implemented the following tests:

```
    testDshNewAppAssignsSpecifiedDOMAINAsNewAppsDefaultDomainIfDOMAINIsSpecified()
    testDshNewAppRunsWithErrorIfSpecifiedDOMAINIsNotAValidDomain()
```
This resolves issue #83 

All `dsh -n` App tests are passing.
