### PR TITLE
Issue153 | WebUI is now stable, and has replaced ResponseUI in index.php

### DIFF
--- a/Tests/Unit/abstractions/component/UserInterface/WebUITest.php
+++ b/Tests/Unit/abstractions/component/UserInterface/WebUITest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace UnitTests\abstractions\component\UserInterface;
+
+use UnitTests\abstractions\component\UserInterface\ResponseUITest as ResponseUITestBase;
+use DarlingDataManagementSystem\abstractions\component\UserInterface\WebUI as WebUIBase;
+use UnitTests\interfaces\component\UserInterface\TestTraits\WebUITestTrait as WebUITestInterface;
+use UnitTests\interfaces\component\UserInterface\TestTraits\ResponseUITestTrait as ResponseUITestInterface;
+
+class WebUITest extends ResponseUITestBase
+{
+    use ResponseUITestInterface, WebUITestInterface {
+        WebUITestInterface::expectedOutput insteadof ResponseUITestInterface;
+    }
+
+    public function setUp(): void
+    {
+        $this->setWebUI(
+            $this->getMockForAbstractClass(
+                WebUIBase::class,
+                $this->getWebUITestArgs()
+            )
+        );
+        $this->setWebUIParentTestInstances();
+    }
+
+}

--- a/Tests/Unit/classes/component/UserInterface/WebUITest.php
+++ b/Tests/Unit/classes/component/UserInterface/WebUITest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace UnitTests\classes\component\UserInterface;
+
+use DarlingDataManagementSystem\classes\component\UserInterface\WebUI as CoreWebUI;
+use UnitTests\abstractions\component\UserInterface\WebUITest as WebUITestBase;
+
+class WebUITest extends WebUITestBase
+{
+    public function setUp(): void
+    {
+        $this->setWebUI(
+            new CoreWebUI(
+                ...$this->getWebUITestArgs()
+            )
+        );
+        $this->setWebUIParentTestInstances();
+    }
+}

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
@@ -28,7 +28,7 @@ use RuntimeException as PHPRuntimeException;
 trait ResponseUITestTrait
 {
 
-    private ResponseUIInterface $responseUI;
+    protected ResponseUIInterface $responseUI;
 
     public static function generateTestOutputComponent(): OutputComponentInterface
     {
@@ -78,12 +78,12 @@ trait ResponseUITestTrait
     /**
      * @return array<ComponentInterface>
      */
-    private static function readAllFromContainer(string $container): array
+    protected static function readAllFromContainer(string $container): array
     {
         return self::getComponentCrud()->readAll(self::expectedAppLocation(), self::getTestComponentContainer());
     }
 
-    private static function deleteAllInContainer(string $container): void
+    protected static function deleteAllInContainer(string $container): void
     {
         foreach(self::getComponentCrud()->readAll(self::expectedAppLocation(), $container) as $storable)
         {
@@ -189,7 +189,7 @@ trait ResponseUITestTrait
         );
     }
 
-    private static function getComponentCrud(): ComponentCrudInterface
+    protected static function getComponentCrud(): ComponentCrudInterface
     {
         return new CoreComponentCrud(
             new CoreStorable(
@@ -202,7 +202,7 @@ trait ResponseUITestTrait
         );
     }
 
-    private static function getStandardStorageDriver(): StorageDriverInterface
+    protected static function getStandardStorageDriver(): StorageDriverInterface
     {
         return new CoreStorageDriver(
             new CoreStorable(
@@ -227,7 +227,7 @@ trait ResponseUITestTrait
     /**
      * @return array<ResponseInterface>
      */
-    private function expectedResponses(): array
+    protected function expectedResponses(): array
     {
         return $this->getResponseUI()->export()['router']->getResponses(
             self::expectedAppLocation(),
@@ -238,7 +238,7 @@ trait ResponseUITestTrait
     /**
      * @return array<PositionableInterface>
      */
-    private function sortPositionables(PositionableInterface ...$postionables): array
+    protected function sortPositionables(PositionableInterface ...$postionables): array
     {
         $sorted = [];
         foreach($postionables as $postionable) {
@@ -252,12 +252,12 @@ trait ResponseUITestTrait
         return $sorted;
     }
 
-    private function getRoutersCompoenentCrud(): ComponentCrudInterface
+    protected function getRoutersCompoenentCrud(): ComponentCrudInterface
     {
          return $this->getResponseUI()->export()['router']->export()['crud'];
     }
 
-    private function expectedOutput(): string
+    protected function expectedOutput(): string
     {
         $expectedOutput = '';
         $expectedResponses = $this->expectedResponses();

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace UnitTests\interfaces\component\UserInterface\TestTraits;
+
+use DarlingDataManagementSystem\interfaces\component\UserInterface\WebUI as WebUIInterface;
+use DarlingDataManagementSystem\interfaces\component\Web\Routing\Router as RouterInterface;
+use DarlingDataManagementSystem\interfaces\component\Web\Routing\Response as ResponseInterface;
+use DarlingDataManagementSystem\interfaces\primary\Storable as StorableInterface;
+use DarlingDataManagementSystem\interfaces\primary\Switchable as SwitchableInterface;
+use DarlingDataManagementSystem\interfaces\primary\Positionable as PositionableInterface;
+use DarlingDataManagementSystem\interfaces\component\ResponseUI as ResponseUIInterface;
+use DarlingDataManagementSystem\classes\primary\Storable as CoreStorable;
+use DarlingDataManagementSystem\classes\primary\Switchable as CoreSwitchable;
+use DarlingDataManagementSystem\classes\primary\Positionable as CorePositionable;
+use RuntimeException as PHPRuntimeException;
+
+trait WebUITestTrait
+{
+
+    private WebUIInterface $webUI;
+
+    protected function setWebUIParentTestInstances(): void
+    {
+        $this->setResponseUI($this->getWebUI());
+        $this->setResponseUIParentTestInstances();
+    }
+
+    public function getWebUI(): WebUIInterface
+    {
+        return $this->webUI;
+    }
+
+    public function setWebUI(WebUIInterface $webUI): void
+    {
+        $this->webUI = $webUI;
+    }
+
+    /**
+     * @return array{0: StorableInterface, 1: SwitchableInterface, 2: PositionableInterface, 3: RouterInterface}
+     */
+    public function getWebUITestArgs(): array
+    {
+        return [
+            new CoreStorable(
+                'MockWebUIName',
+                self::expectedAppLocation(),
+                self::getTestComponentContainer()
+            ),
+            new CoreSwitchable(),
+            new CorePositionable(),
+            self::getRouter()
+        ];
+    }
+
+    protected function expectedOutput(): string
+    {
+        return parent::expectedOutput();;
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -50,16 +50,16 @@
         },
         {
             "name": "darling/ddms-app-packages",
-            "version": "v1.3.1",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/ddmsAppPackages.git",
-                "reference": "5846c1db2c6da576b33a32fec2c905425adfb925"
+                "reference": "7f97df8afedc95c624c5caa805e648983561cec3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/ddmsAppPackages/zipball/5846c1db2c6da576b33a32fec2c905425adfb925",
-                "reference": "5846c1db2c6da576b33a32fec2c905425adfb925",
+                "url": "https://api.github.com/repos/sevidmusic/ddmsAppPackages/zipball/7f97df8afedc95c624c5caa805e648983561cec3",
+                "reference": "7f97df8afedc95c624c5caa805e648983561cec3",
                 "shasum": ""
             },
             "type": "library",
@@ -76,9 +76,9 @@
             "description": "A collection of App Packages that create Darling Data Management System Apps",
             "support": {
                 "issues": "https://github.com/sevidmusic/ddmsAppPackages/issues",
-                "source": "https://github.com/sevidmusic/ddmsAppPackages/tree/v1.3.1"
+                "source": "https://github.com/sevidmusic/ddmsAppPackages/tree/v1.3.5"
             },
-            "time": "2021-05-15T16:24:01+00:00"
+            "time": "2021-05-19T01:33:03+00:00"
         }
     ],
     "packages-dev": [
@@ -603,16 +603,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.87",
+            "version": "0.12.88",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d464e00776afb711f419faffa96826dc02e4d145"
+                "reference": "464d1a81af49409c41074aa6640ed0c4cbd9bb68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d464e00776afb711f419faffa96826dc02e4d145",
-                "reference": "d464e00776afb711f419faffa96826dc02e4d145",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/464d1a81af49409c41074aa6640ed0c4cbd9bb68",
+                "reference": "464d1a81af49409c41074aa6640ed0c4cbd9bb68",
                 "shasum": ""
             },
             "require": {
@@ -643,7 +643,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.87"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.88"
             },
             "funding": [
                 {
@@ -659,7 +659,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-12T15:17:52+00:00"
+            "time": "2021-05-17T12:24:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/core/abstractions/component/UserInterface/ResponseUI.php
+++ b/core/abstractions/component/UserInterface/ResponseUI.php
@@ -17,7 +17,7 @@ use RuntimeException as PHPRuntimeException;
 abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInterface
 {
 
-    private RouterInterface $router;
+    protected RouterInterface $router;
 
     public function __construct(StorableInterface $storable, SwitchableInterface $switchable, PositionableInterface $positionable, RouterInterface $router)
     {
@@ -28,7 +28,7 @@ abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInter
     /**
      * @return array<string, PositionableInterface>
      */
-    private function sortPositionables(PositionableInterface ...$postionables): array
+    protected function sortPositionables(PositionableInterface ...$postionables): array
     {
         $sorted = [];
         foreach($postionables as $postionable) {
@@ -43,7 +43,7 @@ abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInter
     }
 
 
-    private function getRoutersComponentCrud(): ComponentCrudInterface
+    protected function getRoutersComponentCrud(): ComponentCrudInterface
     {
         return $this->router->export()['crud'];
     }

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DarlingDataManagementSystem\abstractions\component\UserInterface;
+
+use DarlingDataManagementSystem\abstractions\component\UserInterface\ResponseUI as ResponseUIInterface;
+use DarlingDataManagementSystem\interfaces\component\UserInterface\WebUI as WebUIInterface;
+
+abstract class WebUI extends ResponseUIInterface implements WebUIInterface
+{
+
+}

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -4,8 +4,76 @@ namespace DarlingDataManagementSystem\abstractions\component\UserInterface;
 
 use DarlingDataManagementSystem\abstractions\component\UserInterface\ResponseUI as ResponseUIInterface;
 use DarlingDataManagementSystem\interfaces\component\UserInterface\WebUI as WebUIInterface;
+use DarlingDataManagementSystem\classes\component\Web\App as CoreApp;
+use DarlingDataManagementSystem\interfaces\component\Web\Routing\Response as ResponseInterface;
+use DarlingDataManagementSystem\interfaces\component\OutputComponent as OutputComponentInterface;
+use RuntimeException as PHPRuntimeException;
+
+
 
 abstract class WebUI extends ResponseUIInterface implements WebUIInterface
 {
+
+    private const DOCTYPE = '<!DOCTYPE html>' . PHP_EOL;
+    private const OPENHTML = '<html lang="en">' . PHP_EOL;
+    private const OPENHEAD = '<head>' . PHP_EOL;
+    private const CLOSEHEAD = '</head>' . PHP_EOL;
+    private const OPENBODY = '<body>' . PHP_EOL;
+    private const CLOSEBODY = '</body>' . PHP_EOL;
+    private const CLOSEHTML = '</html>' . PHP_EOL;
+
+    private function buildOutputWithHtmlStructure(): string
+    {
+        $expectedOutput = self::DOCTYPE . self::OPENHTML . self::OPENHEAD;
+        $actualOutput = '';
+        $expectedResponses = $this->router->getResponses(
+            CoreApp::deriveNameLocationFromRequest($this->router->getRequest()),
+            ResponseInterface::RESPONSE_CONTAINER
+        );
+        $sortedResponses = $this->sortPositionables(...$expectedResponses);;
+        /**
+         * @var ResponseInterface $response
+         */
+        foreach($sortedResponses as $response)
+        {
+            if($response->getPosition() >= 0 && !str_contains($expectedOutput, self::CLOSEHEAD . self::OPENBODY)) {
+                $expectedOutput .= self::CLOSEHEAD . self::OPENBODY;
+            }
+            $outputComponents = [];
+            foreach($response->getOutputComponentStorageInfo() as $storable)
+            {
+                $component = $this->getRoutersComponentCrud()->read($storable);
+                $classImplements = class_implements($component);
+                $isAnOutputComponent = (is_array($classImplements) ? in_array(OutputComponentInterface::class, $classImplements) : false);
+                if($isAnOutputComponent === true)
+                {
+                    /**
+                     * @var OutputComponentInterface $component
+                     */
+                    array_push($outputComponents, $component);
+                }
+            }
+            $sortedOutputComponents = $this->sortPositionables(...$outputComponents);
+            /**
+             * @var OutputComponentInterface $outputComponent
+             */
+            foreach($sortedOutputComponents as $outputComponent)
+            {
+                $expectedOutput .= $outputComponent->getOutput();
+                $actualOutput .= $outputComponent->getOutput();
+            }
+        }
+        if(empty($actualOutput))
+        {
+            throw new PHPRuntimeException('There is nothing to show for this request.');
+        }
+        return $expectedOutput . self::CLOSEBODY . self::CLOSEHTML;
+    }
+
+    public function getOutput(): string
+    {
+        $this->import(['output' => $this->buildOutputWithHtmlStructure()]);
+        return ($this->getState() === true ? $this->export()['output'] : '');
+    }
 
 }

--- a/core/classes/component/UserInterface/WebUI.php
+++ b/core/classes/component/UserInterface/WebUI.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace DarlingDataManagementSystem\classes\component\UserInterface;
+
+use DarlingDataManagementSystem\abstractions\component\UserInterface\WebUI as WebUIBase;
+use DarlingDataManagementSystem\interfaces\component\UserInterface\WebUI as WebUIInterface;
+
+class WebUI extends WebUIBase implements WebUIInterface
+{
+    /**
+     * This is a generic implementation, it does not require
+     * any additional logic, the WebUIBase class
+     * fulfills the requirements of the WebUIInterface.
+     */
+}

--- a/core/interfaces/component/UserInterface/WebUI.php
+++ b/core/interfaces/component/UserInterface/WebUI.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DarlingDataManagementSystem\interfaces\component\UserInterface;
+
+use DarlingDataManagementSystem\interfaces\component\UserInterface\ResponseUI;
+
+interface WebUI extends ResponseUI
+{
+
+}

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 use DarlingDataManagementSystem\classes\component\Crud\ComponentCrud;
 use DarlingDataManagementSystem\classes\component\Driver\Storage\FileSystem\JsonStorageDriver;
 use DarlingDataManagementSystem\classes\component\Factory\PrimaryFactory;
-use DarlingDataManagementSystem\classes\component\UserInterface\ResponseUI;
+use DarlingDataManagementSystem\classes\component\UserInterface\WebUI;
 use DarlingDataManagementSystem\classes\component\Web\App;
 use DarlingDataManagementSystem\classes\component\Web\Routing\Request;
 use DarlingDataManagementSystem\classes\component\Web\Routing\Router;
@@ -17,7 +17,7 @@ $currentRequest = new Request(new Storable('CurrentRequest', 'Requests', 'Index'
 $appComonentsFactory = AppBuilder::getAppsAppComponentsFactory(strval(basename(__DIR__)), $currentRequest->getUrl());
 
 try {
-    $userInterface = new ResponseUI(
+    $userInterface = new WebUI(
         $appComonentsFactory->getPrimaryFactory()->buildStorable('AppUI', 'Index'),
         $appComonentsFactory->getPrimaryFactory()->buildSwitchable(),
         $appComonentsFactory->getPrimaryFactory()->buildPositionable(0),


### PR DESCRIPTION
`DarlingDataManagementSystem\interfaces\component\UserInterface\WebUI`  |  `DarlingDataManagementSystem\interfaces\component\UserInterface\ResponseUI`:

Continued development of WebUI, this continues to address issue #153.
The WebUI is now responsible for adding html structure where appropriate to the collective output of the Response and GlobalResponses that respond to the current Request.

Any Responses or GlobalResponses assigned to position < 0 will have their output
placed within the <head> and </head> tags, any Responses or GlobalResponses
assigned to position >= 0 will have their output placed within the
<body> and </body> tags.

Also, refactored ResponseUI, changed private scope to protected where
appropriate to give child classes access to methods and properties
that may be useful to child classes. This maed implementing the WebUI easier since much of the logic is exactly the same as the ResponseUI.

All PhpUnit and PhpStan --level 8 tests are passing, also tested
manually using existing Apps from [ddmsAppPackages](https://github.com/sevidmusic/ddmsAppPackages) repo, all tests
passed,.

Issue #153 can be closed, and a new issue should be opened to address incorporating `<title>$_GET['title'] ?? $_GET['page'] ?? DefaultTitle</title>` in WebUI output.

