### PR TITLE
Resolved issue #161, renamed App::deriveNameLocationFromRequest() to App::deriveAppLocationFromRequest()

### DIFF
--- a/Tests/Unit/interfaces/component/Factory/App/TestTraits/AppComponentsFactoryTestTrait.php
+++ b/Tests/Unit/interfaces/component/Factory/App/TestTraits/AppComponentsFactoryTestTrait.php
@@ -182,7 +182,7 @@ trait AppComponentsFactoryTestTrait
     public function testBuildDomainReturnsRequestWhoseNameMatchesExpectedAppNameLocation(): void
     {
         $this->assertEquals(
-            CoreApp::deriveNameLocationFromRequest($this->getTestDomain()),
+            CoreApp::deriveAppLocationFromRequest($this->getTestDomain()),
             $this->getAppComponentsFactory()::buildDomain(
                 $this->getTestDomain()->getUrl(),
             )->getName()
@@ -192,7 +192,7 @@ trait AppComponentsFactoryTestTrait
     public function testBuildDomainReturnsRequestWhoseLocationMatchesExpectedAppNameLocation(): void
     {
         $this->assertEquals(
-            CoreApp::deriveNameLocationFromRequest($this->getTestDomain()),
+            CoreApp::deriveAppLocationFromRequest($this->getTestDomain()),
             $this->getAppComponentsFactory()::buildDomain(
                 $this->getTestDomain()->getUrl(),
             )->getLocation()
@@ -202,7 +202,7 @@ trait AppComponentsFactoryTestTrait
     public function testBuildDomainReturnsRequestWhoseContainerMatchesExpectedAppNameLocation(): void
     {
         $this->assertEquals(
-            CoreApp::deriveNameLocationFromRequest($this->getTestDomain()),
+            CoreApp::deriveAppLocationFromRequest($this->getTestDomain()),
             $this->getAppComponentsFactory()::buildDomain(
                 $this->getTestDomain()->getUrl(),
             )->getContainer()

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
@@ -156,7 +156,7 @@ trait ResponseUITestTrait
 
     protected static function expectedAppLocation(): string
     {
-        return CoreApp::deriveNameLocationFromRequest(self::getIndependantTestRequest());
+        return CoreApp::deriveAppLocationFromRequest(self::getIndependantTestRequest());
     }
 
     protected static function getTestComponentContainer(): string

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/StandardUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/StandardUITestTrait.php
@@ -40,7 +40,7 @@ trait StandardUITestTrait
     public function testAppLocationPropertyMatchesAppLocationDerivedFromRoutersRequest(): void
     {
         $this->assertEquals(
-            App::deriveNameLocationFromRequest($this->getRouter()->getRequest()),
+            App::deriveAppLocationFromRequest($this->getRouter()->getRequest()),
             $this->getStandardUI()->export()['appLocation']
         );
     }

--- a/Tests/Unit/interfaces/component/Web/Routing/TestTraits/GlobalResponseTestTrait.php
+++ b/Tests/Unit/interfaces/component/Web/Routing/TestTraits/GlobalResponseTestTrait.php
@@ -18,13 +18,13 @@ trait GlobalResponseTestTrait
     private function insteadTestRespondsToRequestReturnsTrueIfValueReturnedByPassingSuppliedRequestToAnAppImplementationsDeriveNameLocationFromRequestMethodMatchesResponsesLocation(): void
     {
         $request = $this->getMockRequest();
-        if ($this->getGlobalResponse()->getLocation() === CoreApp::deriveNameLocationFromRequest($request)) {
+        if ($this->getGlobalResponse()->getLocation() === CoreApp::deriveAppLocationFromRequest($request)) {
             $this->assertTrue(
                 $this->getGlobalResponse()->respondsToRequest(
                     $request,
                     $this->getMockCrud()
                 ),
-                'respondsToRequest() must return true for any Request made to the App the GlobalResponse belongs to, i.e. if the return value of App::deriveNameLocationFromRequest(Request) is equal to Response->getLocation() then Response->respondsToRequest(Request) MUST return true.'
+                'respondsToRequest() must return true for any Request made to the App the GlobalResponse belongs to, i.e. if the return value of App::deriveAppLocationFromRequest(Request) is equal to Response->getLocation() then Response->respondsToRequest(Request) MUST return true.'
             );
         }
     }
@@ -53,7 +53,7 @@ trait GlobalResponseTestTrait
                 $request,
                 $this->getMockCrud()
             ),
-            'respondsToRequest() must return false for any Request made to an App other than the App the GlobalResponse belongs to, i.e. if the return value of App::deriveNameLocationFromRequest(Request) is NOT equal to Response->getLocation() then Response->respondsToRequest(Request) MUST return false'
+            'respondsToRequest() must return false for any Request made to an App other than the App the GlobalResponse belongs to, i.e. if the return value of App::deriveAppLocationFromRequest(Request) is NOT equal to Response->getLocation() then Response->respondsToRequest(Request) MUST return false'
         );
     }
 

--- a/Tests/Unit/interfaces/component/Web/TestTraits/AppTestTrait.php
+++ b/Tests/Unit/interfaces/component/Web/TestTraits/AppTestTrait.php
@@ -112,20 +112,20 @@ trait AppTestTrait
         }
         $this->assertEquals(
             $expectedNameLocation,
-            $this->getApp()::deriveNameLocationFromRequest($this->getMockRequest())
+            $this->getApp()::deriveAppLocationFromRequest($this->getMockRequest())
         );
     }
 
     public function testLocationWasSetUsingDeriveAppNameLocationFromRequestMethod(): void
     {
-        $expectedNameLocation = CoreApp::deriveNameLocationFromRequest($this->getMockRequest());
+        $expectedNameLocation = CoreApp::deriveAppLocationFromRequest($this->getMockRequest());
         $this->assertEquals($expectedNameLocation, $this->getApp()->getLocation());
         $this->assertEquals($expectedNameLocation, $this->getApp()->export()['storable']->getLocation());
     }
 
     public function testNameWasSetUsingDeriveAppNameLocationFromRequestMethodIfNameWasNotSpecified(): void
     {
-        $expectedNameLocation = CoreApp::deriveNameLocationFromRequest($this->getMockRequest());
+        $expectedNameLocation = CoreApp::deriveAppLocationFromRequest($this->getMockRequest());
         $this->assertEquals($expectedNameLocation, $this->getApp()->getName());
         $this->assertEquals($expectedNameLocation, $this->getApp()->export()['storable']->getName());
     }
@@ -142,7 +142,7 @@ trait AppTestTrait
     private function purgeAppStorage(): void
     {
         $installedApps = $this->getMockCrud()->readAll(
-            CoreApp::deriveNameLocationFromRequest($this->getMockRequest()),
+            CoreApp::deriveAppLocationFromRequest($this->getMockRequest()),
             CoreApp::APP_CONTAINER
         );
         foreach ($installedApps as $storable) {

--- a/Tests/Unit/interfaces/utility/TestTraits/AppBuilderTestTrait.php
+++ b/Tests/Unit/interfaces/utility/TestTraits/AppBuilderTestTrait.php
@@ -300,7 +300,7 @@ trait AppBuilderTestTrait
 
     private function determinAppsLocation(AppComponentsFactoryInterface $appComponentsFactory): string
     {
-        return $appComponentsFactory->getApp()->deriveNameLocationFromRequest(
+        return $appComponentsFactory->getApp()->deriveAppLocationFromRequest(
             $appComponentsFactory->getApp()->getAppDomain()
         );
     }

--- a/core/abstractions/component/Factory/App/AppComponentsFactory.php
+++ b/core/abstractions/component/Factory/App/AppComponentsFactory.php
@@ -241,9 +241,9 @@ abstract class AppComponentsFactory extends StoredComponentFactoryBase implement
         );
         $domain->import(['url' => $url]);
         $actualStorable = new CoreStorable(
-            CoreApp::deriveNameLocationFromRequest($domain),
-            CoreApp::deriveNameLocationFromRequest($domain),
-            CoreApp::deriveNameLocationFromRequest($domain),
+            CoreApp::deriveAppLocationFromRequest($domain),
+            CoreApp::deriveAppLocationFromRequest($domain),
+            CoreApp::deriveAppLocationFromRequest($domain),
         );
         $domain->import(['storable' => $actualStorable]);
         return $domain;

--- a/core/abstractions/component/UserInterface/ResponseUI.php
+++ b/core/abstractions/component/UserInterface/ResponseUI.php
@@ -52,7 +52,7 @@ abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInter
     {
         $expectedOutput = '';
         $expectedResponses = $this->router->getResponses(
-            CoreApp::deriveNameLocationFromRequest($this->router->getRequest()),
+            CoreApp::deriveAppLocationFromRequest($this->router->getRequest()),
             ResponseInterface::RESPONSE_CONTAINER
         );
         $sortedResponses = $this->sortPositionables(...$expectedResponses);;

--- a/core/abstractions/component/UserInterface/StandardUI.php
+++ b/core/abstractions/component/UserInterface/StandardUI.php
@@ -31,7 +31,7 @@ abstract class StandardUI extends OutputComponentBase implements StandardUIInter
     {
         parent::__construct($storable, $switchable, $positionable);
         $this->router = $router;
-        $this->appLocation = CoreApp::deriveNameLocationFromRequest($router->getRequest());
+        $this->appLocation = CoreApp::deriveAppLocationFromRequest($router->getRequest());
     }
 
     public function getOutput(): string

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -27,7 +27,7 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         $expectedOutput = self::DOCTYPE . self::OPENHTML . self::OPENHEAD;
         $actualOutput = '';
         $expectedResponses = $this->router->getResponses(
-            CoreApp::deriveNameLocationFromRequest($this->router->getRequest()),
+            CoreApp::deriveAppLocationFromRequest($this->router->getRequest()),
             ResponseInterface::RESPONSE_CONTAINER
         );
         $sortedResponses = $this->sortPositionables(...$expectedResponses);;

--- a/core/abstractions/component/Web/App.php
+++ b/core/abstractions/component/Web/App.php
@@ -23,14 +23,14 @@ abstract class App extends SwitchableComponentBase implements AppInterface
             $actualName = preg_replace("/[^A-Za-z0-9]/", '', $appName);
         }
         $storable = new CoreStorable(
-            ($actualName ?? self::deriveNameLocationFromRequest($request)),
-            self::deriveNameLocationFromRequest($request),
+            ($actualName ?? self::deriveAppLocationFromRequest($request)),
+            self::deriveAppLocationFromRequest($request),
             self::APP_CONTAINER
         );
         parent::__construct($storable, $switchable);
     }
 
-    public static function deriveNameLocationFromRequest(RequestInterface $request): string
+    public static function deriveAppLocationFromRequest(RequestInterface $request): string
     {
         $nameLocation = preg_replace(
             "/[^A-Za-z0-9]/",

--- a/core/abstractions/component/Web/Routing/GlobalResponse.php
+++ b/core/abstractions/component/Web/Routing/GlobalResponse.php
@@ -24,7 +24,7 @@ abstract class GlobalResponse extends CoreResponse implements GlobalResponseInte
 
     public function respondsToRequest(RequestInterface $request, ComponentCrudInterface $componentCrud): bool
     {
-        if (CoreApp::deriveNameLocationFromRequest($request) === $this->getLocation()) {
+        if (CoreApp::deriveAppLocationFromRequest($request) === $this->getLocation()) {
             return true;
         }
         return false;

--- a/core/abstractions/utility/AppBuilder.php
+++ b/core/abstractions/utility/AppBuilder.php
@@ -24,7 +24,7 @@ abstract class AppBuilder implements AppBuilderInterface
             $appComponentsFactory = $appComponentsFactory->getComponentCrud()->readByNameAndType(
                 $appComponentsFactory->getName(),
                 $appComponentsFactory->getType(),
-                CoreApp::deriveNameLocationFromRequest($domainRequest),
+                CoreApp::deriveAppLocationFromRequest($domainRequest),
                 AppComponentsFactory::CONTAINER
             );
         } catch(Exception $e) {

--- a/core/interfaces/component/Web/App.php
+++ b/core/interfaces/component/Web/App.php
@@ -11,7 +11,7 @@ interface App extends CoreSwitchableComponent
 
     public const APP_CONTAINER = "APP";
 
-    public static function deriveNameLocationFromRequest(RequestInterface $request): string;
+    public static function deriveAppLocationFromRequest(RequestInterface $request): string;
 
     public function getAppDomain(): RequestInterface;
 


### PR DESCRIPTION
Resolved issue #161, renamed `App::deriveNameLocationFromRequest()` to `App::deriveAppLocationFromRequest()`. All `phpunit` and `phpstan --level 8` tests are passing.