### PR TITLE
issue166: Resolved issue #166

### DIFF
--- a/Tests/Unit/interfaces/component/Web/Routing/TestTraits/ResponseTestTrait.php
+++ b/Tests/Unit/interfaces/component/Web/Routing/TestTraits/ResponseTestTrait.php
@@ -5,6 +5,7 @@ namespace UnitTests\interfaces\component\Web\Routing\TestTraits;
 use DarlingDataManagementSystem\classes\component\Crud\ComponentCrud as CoreComponentCrud;
 use DarlingDataManagementSystem\classes\component\Driver\Storage\FileSystem\JsonStorageDriver as CoreJsonStorageDriver;
 use DarlingDataManagementSystem\classes\component\OutputComponent as CoreOutputComponent;
+use DarlingDataManagementSystem\classes\component\Web\App as CoreApp;
 use DarlingDataManagementSystem\classes\component\Web\Routing\Request as CoreRequest;
 use DarlingDataManagementSystem\classes\component\Web\Routing\Response as CoreResponse;
 use DarlingDataManagementSystem\classes\primary\Positionable as CorePositionable;
@@ -51,6 +52,19 @@ trait ResponseTestTrait
                 $this->getMockCrud()
             ),
             'respondsToRequest() must return true for assigned request.'
+        );
+    }
+
+    public function testRespondsToRequestReturnsTrueForAnyRequestWhoseAssignedUrlContainsAGetParameterNamed_request_WhoseAssignedValueMatchesRespectiveResponsesName(): void
+    {
+        $unassignedRequestUrlDefinesGetParam_request_WithValueResponseName = $this->getMockRequest();
+        $unassignedRequestUrlDefinesGetParam_request_WithValueResponseName->import(['url' => 'http://DEFAULT/index.php?request=' . $this->getResponse()->getName()]);
+        $this->assertTrue(
+            $this->getResponse()->respondsToRequest(
+                $unassignedRequestUrlDefinesGetParam_request_WithValueResponseName,
+                $this->getMockCrud()
+            ),
+            'respondsToRequest() must return true for any Request that defines a GET parameter named \'request\' whose assigned value matches the respective Response\'s name.'
         );
     }
 

--- a/core/abstractions/component/Web/Routing/GlobalResponse.php
+++ b/core/abstractions/component/Web/Routing/GlobalResponse.php
@@ -24,6 +24,9 @@ abstract class GlobalResponse extends CoreResponse implements GlobalResponseInte
 
     public function respondsToRequest(RequestInterface $request, ComponentCrudInterface $componentCrud): bool
     {
+        if(parent::respondsToRequest($request, $componentCrud) === true) {
+            return true;
+        }
         if (CoreApp::deriveAppLocationFromRequest($request) === $this->getLocation()) {
             return true;
         }

--- a/core/abstractions/component/Web/Routing/Response.php
+++ b/core/abstractions/component/Web/Routing/Response.php
@@ -44,8 +44,19 @@ abstract class Response extends SwitchableComponentBase implements ResponseInter
         parent::__construct($st, $switchable);
     }
 
+    private function responseWasRequestedByName(RequestInterface $request) : bool
+    {
+        if(str_contains($request->getUrl(), '?request=' . $this->getName()) || str_contains($request->getUrl(), '&request=' . $this->getName())) {
+            return true;
+        }
+        return false;
+    }
+
     public function respondsToRequest(RequestInterface $request, ComponentCrudInterface $crud): bool
     {
+        if($this->responseWasRequestedByName($request)) {
+            return true;
+        }
         foreach ($this->getRequestStorageInfo() as $storable) {
             $storedRequest = $crud->read($storable);
             if ($this->isARequest($storedRequest) === false) {


### PR DESCRIPTION
Responses will now respond to any `Request`, even if the `Request` is not assigned to the `Response`, that defines `a $_GET` variable named `request` in it's url's query string that is assigned the respective `Response`'s name. 

Also, refactored `GlobalResponse::respondsToRequest()` to always return true if `parent::respondsToRequest()` returns true in order to accomodate this refactor, this does not at all interfere with the `GlobalResponse`'s intended logic. 

All phpunit and phpstan --level 8 tests are passing. 

Also, tested manually by building an `App` and trying various combinations of query strings with the `request` variable assigned the appropriate `Response`'s name, as well as manually tested requesting mutliple `Responses` by name, all manual tests also passed.