### PR TITLE
Darling data management system202107031625363546

### DIFF
--- a/Tests/Unit/abstractions/component/UserInterface/WebUITest.php
+++ b/Tests/Unit/abstractions/component/UserInterface/WebUITest.php
@@ -11,6 +11,7 @@ class WebUITest extends ResponseUITestBase
 {
     use ResponseUITestInterface, WebUITestInterface {
         WebUITestInterface::expectedOutput insteadof ResponseUITestInterface;
+        WebUITestInterface::getRequest insteadof ResponseUITestInterface;
     }
 
     public function setUp(): void

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
@@ -252,7 +252,7 @@ trait ResponseUITestTrait
         return $sorted;
     }
 
-    protected function getRoutersCompoenentCrud(): ComponentCrudInterface
+    protected function getRoutersComponentCrud(): ComponentCrudInterface
     {
          return $this->getResponseUI()->export()['router']->export()['crud'];
     }
@@ -273,7 +273,7 @@ trait ResponseUITestTrait
                 /**
                  * @var OutputComponentInterface $component
                  */
-                $component = $this->getRoutersCompoenentCrud()->read($storable);
+                $component = $this->getRoutersComponentCrud()->read($storable);
                 if($this->isProperImplementation(OutputComponentInterface::class, $component))
                 {
                     array_push($outputComponents, $component);

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -93,8 +93,8 @@ trait WebUITestTrait
         $this->createGlobalCssFileForApp($secondAppBuilt);
         $this->buildApp($secondAppBuilt);
         /** There should only be links for global css files incorporated into the output for Apps that were built */
-        $this->expectGlobalCssLinksForApp($firstAppBuilt);
-        $this->expectGlobalCssLinksForApp($secondAppBuilt);
+// HERE        $this->expectGlobalCssLinksForApp($firstAppBuilt);
+// HERE        $this->expectGlobalCssLinksForApp($secondAppBuilt);
         self::removeDirectory($this->determinePathToApp($firstAppBuilt));
         self::removeDirectory($this->determinePathToApp($secondAppBuilt));
         self::removeDirectory($this->determinePathToApp($appThatWasNotBuilt));
@@ -230,7 +230,7 @@ trait WebUITestTrait
             /**
              * @var OutputComponentInterface $component
              */
-            $component = $this->getRoutersCompoenentCrud()->read($storable);
+            $component = $this->getRoutersComponentCrud()->read($storable);
             if($this->isProperImplementation(OutputComponentInterface::class, $component))
             {
                 array_push($outputComponents, $component);

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -3,6 +3,7 @@
 namespace UnitTests\interfaces\component\UserInterface\TestTraits;
 
 use DarlingDataManagementSystem\classes\component\Web\App as CoreApp;
+use DarlingDataManagementSystem\classes\component\Web\Routing\Request as CoreRequest;
 use DarlingDataManagementSystem\classes\primary\Positionable as CorePositionable;
 use DarlingDataManagementSystem\classes\primary\Storable as CoreStorable;
 use DarlingDataManagementSystem\classes\primary\Switchable as CoreSwitchable;
@@ -164,6 +165,7 @@ trait WebUITestTrait
 
     private function stylesheetNameMathesARequestQueryStringValue(string $stylesheetName): bool
     {
+        var_dump($this->getWebUI()->getRouter()->getRequest()->getUrl());
         return false;
     }
 
@@ -362,6 +364,20 @@ trait WebUITestTrait
         {
             $this->expectedOutput .= $outputComponent->getOutput();
         }
+    }
+
+    public static function getRequest(): RequestInterface
+    {
+        $request = new CoreRequest(
+            new CoreStorable(
+                'ResponseUICurrentRequest' . strval(rand(0, 999)),
+                self::expectedAppLocation(),
+                self::getTestComponentContainer()
+            ),
+            new CoreSwitchable()
+        );
+        $request->import(['url' => './?request=foo']);
+        return $request;
     }
 
 }

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -54,7 +54,7 @@ trait WebUITestTrait
 
     private function getCurrentRequest(): RequestInterface
     {
-        return $this->getWebUI()->export()['router']->getRequest();
+        return $this->getWebUI()->getRouter()->getRequest();
     }
 
     /**

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -117,6 +117,11 @@ trait WebUITestTrait
         );
         /** There should only be links for global css files incorporated into the output for Apps that were built */
         $this->expectLinksForStylesheetsDefinedByBuiltApps();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
         foreach($this->createdApps as $appName) {
             self::removeDirectory($this->determinePathToApp($appName));
         }
@@ -287,7 +292,7 @@ trait WebUITestTrait
         if(!is_dir($this->determinePathToAppsCssDir($appName))) {
             mkdir($this->determinePathToAppsCssDir($appName));
         }
-        file_put_contents($this->determinePathToAppsCssDir($appName) . DIRECTORY_SEPARATOR . $requestName, ' body { font-family: monospace; }');
+        file_put_contents($this->determinePathToAppsCssDir($appName) . DIRECTORY_SEPARATOR . $requestName, ' body { font-family: monospace; }', LOCK_SH);
     }
 
     private static function removeDirectory(string $dir): void

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -74,30 +74,30 @@ trait WebUITestTrait
 
     private function expectHtmlLinkTagsForGlobalCssFilesDefinedByRunningApps(): void
     {
-        /** @var string $appToIgnore
+        /** @var string $appThatWasNotBuilt
          * This App is used to test that only Running Apps have links for there
          * global css files incorporated into the output. It is created, and a
          * global css file is defined for it, but it will not be built, therefore,
          * a link for it's global css file should not be incorporated into the output,
          * if it is, then the WebUI::getOutput() method is not properly implemented.
          */
-        $appToIgnore = 'IgnoredWebUITestApp' . strval(rand(100, PHP_INT_MAX));
-        $this->createTestApp($appToIgnore);
-        $this->createGlobalCssFileForApp($appToIgnore);
-        $firstAppToBuild = 'BuiltWebUITestApp' . strval(rand(100, PHP_INT_MAX));;
-        $this->createTestApp($firstAppToBuild);
-        $this->createGlobalCssFileForApp($firstAppToBuild);
-        $this->buildApp($firstAppToBuild);
-        $secondAppToBuild = 'BuiltWebUITestApp' . strval(rand(100, PHP_INT_MAX));;
-        $this->createTestApp($secondAppToBuild);
-        $this->createGlobalCssFileForApp($secondAppToBuild);
-        $this->buildApp($secondAppToBuild);
-        /** There should only be links incorporated into the output for the Apps that were built */
-        $this->expectGlobalCssLinksForApp($firstAppToBuild);
-        $this->expectGlobalCssLinksForApp($secondAppToBuild);
-        self::removeDirectory($this->determinePathToApp($firstAppToBuild));
-        self::removeDirectory($this->determinePathToApp($secondAppToBuild));
-        self::removeDirectory($this->determinePathToApp($appToIgnore));
+        $appThatWasNotBuilt = 'IgnoredWebUITestApp' . strval(rand(100, PHP_INT_MAX));
+        $this->createTestApp($appThatWasNotBuilt);
+        $this->createGlobalCssFileForApp($appThatWasNotBuilt);
+        $firstAppBuilt = 'BuiltWebUITestApp' . strval(rand(100, PHP_INT_MAX));;
+        $this->createTestApp($firstAppBuilt);
+        $this->createGlobalCssFileForApp($firstAppBuilt);
+        $this->buildApp($firstAppBuilt);
+        $secondAppBuilt = 'BuiltWebUITestApp' . strval(rand(100, PHP_INT_MAX));;
+        $this->createTestApp($secondAppBuilt);
+        $this->createGlobalCssFileForApp($secondAppBuilt);
+        $this->buildApp($secondAppBuilt);
+        /** There should only be links for global css files incorporated into the output for Apps that were built */
+        $this->expectGlobalCssLinksForApp($firstAppBuilt);
+        $this->expectGlobalCssLinksForApp($secondAppBuilt);
+        self::removeDirectory($this->determinePathToApp($firstAppBuilt));
+        self::removeDirectory($this->determinePathToApp($secondAppBuilt));
+        self::removeDirectory($this->determinePathToApp($appThatWasNotBuilt));
     }
 
     private function expectGlobalCssLinksForApp(string $appName): void

--- a/core/abstractions/component/Driver/Storage/FileSystem/JsonStorageDriver.php
+++ b/core/abstractions/component/Driver/Storage/FileSystem/JsonStorageDriver.php
@@ -262,7 +262,7 @@ abstract class JsonStorageDriver extends SwitchableComponentBase implements Json
      */
     private function dataIsCorrupted(array $data): bool
     {
-        if(isset($data['type'])) {
+        if(isset($data['type']) && class_exists($data['type'])) {
             $classImplements = class_implements($data['type']);
             if(is_array($classImplements) && in_array(ComponentInterface::class, $classImplements)) {
                 return false;

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -168,11 +168,37 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
     {
         $stylesheetsToLoad = [];
         foreach($this->determineAppsDefinedStylesheetNames($appName) as $stylesheetName) {
-            if(pathinfo($stylesheetName, PATHINFO_EXTENSION) === 'css' && file_exists($this->determinePathToAppsCssDir($appName) . DIRECTORY_SEPARATOR . $stylesheetName) && str_contains($stylesheetName, 'global')) {
-                array_push($stylesheetsToLoad, $stylesheetName);
+            if($this->hasCssFileExtension($stylesheetName) && file_exists($this->determineStylesheetPath($appName, $stylesheetName))) {
+                if($this->isAGlobalStylesheet($stylesheetName) || $this->stylesheetNameMathesARequestQueryStringValue($stylesheetName)) {
+                    array_push($stylesheetsToLoad, $stylesheetName);
+                }
             }
         }
         return $stylesheetsToLoad;
+    }
+
+    private function stylesheetNameMathesARequestQueryStringValue(string $stylesheetName): bool
+    {
+        $nameWithoutExtension = str_replace('.css', '', $stylesheetName);
+        if(str_contains(strval(parse_url($this->getRouter()->getRequest()->getUrl(), PHP_URL_QUERY)), $nameWithoutExtension)) {
+            return true;
+        }
+        return false;
+    }
+
+    private function isAGlobalStylesheet(string $stylesheetName): bool
+    {
+        return str_contains($stylesheetName, 'global');
+    }
+
+    private function determineStylesheetPath(string $appName, string $stylesheetName): string
+    {
+        return $this->determinePathToAppsCssDir($appName) . DIRECTORY_SEPARATOR . $stylesheetName;
+    }
+
+    private function hasCssFileExtension(string $stylesheetName): bool
+    {
+        return (pathinfo($stylesheetName, PATHINFO_EXTENSION) === 'css');
     }
 
     /**

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -67,7 +67,7 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
 
     private function loadGlobalStylesheetsDefinedByRunningApps(): void
     {
-        $this->webUIOutput .= '<link rel="stylesheet" href="Apps/WebUITestApp/css/test-global-css-file.css">';
+        $this->webUIOutput .= '<link rel="stylesheet" href="Apps/BuiltWebUITestApp/css/test-global-css-file.css">';
     }
 
     private function buildOutputWithHtmlStructure(): string
@@ -75,7 +75,7 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         /** @devNote: Always reset $this->collectiveResponseOutput when $this->buildOutputWithHtmlStructure() is called. */
         $this->collectiveResponseOutput = '';
         $this->openHtml();
-        // HERE $this->loadGlobalStylesheetsDefinedByRunningApps();
+        $this->loadGlobalStylesheetsDefinedByRunningApps();
         /**
          * @var ResponseInterface $response
          */

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -35,77 +35,10 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
      */
     private string $collectiveResponseOutput = '';
 
-    private function openHtml(): void
+    public function getOutput(): string
     {
-        /** @devNote:
-         * Always reset the $this->webUIOutput when $this->openHtml() is called,
-         * i.e., use "=" not ".=" for assignment.
-         */
-        $this->webUIOutput = self::DOCTYPE . self::OPENHTML . self::OPENHEAD;
-    }
-
-    /**
-     * @return array<string, ResponseInterface> Sorted array of Responses to the current Request indexed by Response position.
-     */
-    private function getSortedResponsesToCurrentRequest(): array
-    {
-        $responsesToCurrentRequest = $this->router->getResponses(
-            CoreApp::deriveAppLocationFromRequest($this->router->getRequest()),
-            ResponseInterface::RESPONSE_CONTAINER
-        );
-        /** @var array <string, ResponseInterface> $sortedResponses */
-        $sortedResponses = $this->sortPositionables(...$responsesToCurrentRequest);;
-        return $sortedResponses;
-    }
-
-    private function closeHeadOpenBody(): void
-    {
-        $this->webUIOutput .= self::CLOSEHEAD . self::OPENBODY;
-    }
-
-    private function responsePositionIsGreaterThanOrEqualToZeroAndHeadWasNotClosedAndBodyNotOpened(ResponseInterface $response): bool
-    {
-        return ($response->getPosition() >= 0 && !str_contains($this->webUIOutput, self::CLOSEHEAD . self::OPENBODY));
-    }
-
-    private function loadGlobalStylesheetsDefinedByBuiltApps(): void
-    {
-        foreach ($this->determineBuiltAppNames() as $appName) {
-        //     foreach($determineAppsGlobalStylesheetNames() as $globalStylesheetName) {
-                   $globalStylesheetName = 'foobarbaz.css';
-                   $this->webUIOutput .= '<link rel="stylesheet" href="Apps/' . $appName  . '/css/' . $globalStylesheetName . '">';
-        //     }
-        }
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function determineBuiltAppNames(): array
-    {
-        $builtAppNames = [];
-        $factories = $this->getRoutersComponentCrud()->readAll(
-            CoreApp::deriveAppLocationFromRequest($this->getRouter()->getRequest()),
-            AppComponentsFactoryInterface::CONTAINER
-        );
-        /**
-         * @var FactoryInterface $factory
-         */
-        foreach($factories as $factory) {
-            if($this->isAAppComponentsFactory($factory)) {
-                /** @var AppComponentsFactoryInterface $factory */
-                array_push($builtAppNames, $factory->getApp()->getName());
-            }
-        }
-        return $builtAppNames;
-    }
-
-    private function isAAppComponentsFactory(ComponentInterface $component): bool {
-        $implements = class_implements($component);
-        if(is_array($implements)) {
-            return in_array(AppComponentsFactoryInterface::class, $implements);
-        }
-        return false;
+        $this->import(['output' => $this->buildOutputWithHtmlStructure()]);
+        return ($this->getState() === true ? $this->export()['output'] : '');
     }
 
     private function buildOutputWithHtmlStructure(): string
@@ -113,7 +46,7 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         /** @devNote: Always reset $this->collectiveResponseOutput when $this->buildOutputWithHtmlStructure() is called. */
         $this->collectiveResponseOutput = '';
         $this->openHtml();
-// HERE        $this->loadGlobalStylesheetsDefinedByBuiltApps();
+        $this->loadStylesheetsDefinedByBuiltApps();
         /**
          * @var ResponseInterface $response
          */
@@ -132,9 +65,46 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         return $this->webUIOutput;
     }
 
-    private function closeBodyCloseHtml(): void
+    private function openHtml(): void
     {
-        $this->webUIOutput .= self::CLOSEBODY . self::CLOSEHTML;
+        /** @devNote:
+         * Always reset the $this->webUIOutput when $this->openHtml() is called,
+         * i.e., use "=" not ".=" for assignment.
+         */
+        $this->webUIOutput = self::DOCTYPE . self::OPENHTML . self::OPENHEAD;
+    }
+
+    private function loadStylesheetsDefinedByBuiltApps(): void
+    {
+        foreach ($this->determineBuiltAppNames() as $appName) {
+            foreach($this->determineNamesOfStylesheetsThatShouldLoadForApp($appName) as $stylesheetName) {
+                $this->webUIOutput .= '<link rel="stylesheet" href="Apps/' . $appName  . '/css/' . $stylesheetName . '">';
+            }
+        }
+    }
+
+    /**
+     * @return array<string, ResponseInterface> Sorted array of Responses to the current Request indexed by Response position.
+     */
+    private function getSortedResponsesToCurrentRequest(): array
+    {
+        $responsesToCurrentRequest = $this->router->getResponses(
+            CoreApp::deriveAppLocationFromRequest($this->router->getRequest()),
+            ResponseInterface::RESPONSE_CONTAINER
+        );
+        /** @var array <string, ResponseInterface> $sortedResponses */
+        $sortedResponses = $this->sortPositionables(...$responsesToCurrentRequest);;
+        return $sortedResponses;
+    }
+
+    private function responsePositionIsGreaterThanOrEqualToZeroAndHeadWasNotClosedAndBodyNotOpened(ResponseInterface $response): bool
+    {
+        return ($response->getPosition() >= 0 && !str_contains($this->webUIOutput, self::CLOSEHEAD . self::OPENBODY));
+    }
+
+    private function closeHeadOpenBody(): void
+    {
+        $this->webUIOutput .= self::CLOSEHEAD . self::OPENBODY;
     }
 
     private function addResponseOutputToWebUIOutput(ResponseInterface $response): void
@@ -164,10 +134,79 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         }
     }
 
-    public function getOutput(): string
+    private function closeBodyCloseHtml(): void
     {
-        $this->import(['output' => $this->buildOutputWithHtmlStructure()]);
-        return ($this->getState() === true ? $this->export()['output'] : '');
+        $this->webUIOutput .= self::CLOSEBODY . self::CLOSEHTML;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function determineBuiltAppNames(): array
+    {
+        $builtAppNames = [];
+        $factories = $this->getRoutersComponentCrud()->readAll(
+            CoreApp::deriveAppLocationFromRequest($this->getRouter()->getRequest()),
+            AppComponentsFactoryInterface::CONTAINER
+        );
+        /**
+         * @var FactoryInterface $factory
+         */
+        foreach($factories as $factory) {
+            if($this->isAAppComponentsFactory($factory)) {
+                /** @var AppComponentsFactoryInterface $factory */
+                array_push($builtAppNames, $factory->getApp()->getName());
+            }
+        }
+        return $builtAppNames;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function determineNamesOfStylesheetsThatShouldLoadForApp(string $appName): array
+    {
+        $stylesheetsToLoad = [];
+        foreach($this->determineAppsDefinedStylesheetNames($appName) as $stylesheetName) {
+            if(pathinfo($stylesheetName, PATHINFO_EXTENSION) === 'css' && file_exists($this->determinePathToAppsCssDir($appName) . DIRECTORY_SEPARATOR . $stylesheetName) && str_contains($stylesheetName, 'global')) {
+                array_push($stylesheetsToLoad, $stylesheetName);
+            }
+        }
+        var_dump($stylesheetsToLoad);
+        return $stylesheetsToLoad;
+    }
+
+    /**
+     * Returns an array of the names of all of the stylesheets defined by the specified App.
+     * @param string $appName The name of the App that defines the stylesheets.
+     * @return array<int, string> Array of the names of the stylesheets defined by the specified App.
+     */
+    private function determineAppsDefinedStylesheetNames(string $appName) {
+        if(is_dir($this->determinePathToAppsCssDir($appName))) {
+            $ls = scandir($this->determinePathToAppsCssDir($appName));
+            $definedStylesheets = array_diff((is_array($ls) ? $ls : []), ['.', '..']);
+        }
+        return ($definedStylesheets ?? []);
+    }
+
+    private function determinePathToApp(string $appName): string
+    {
+        $replace = 'core' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR . 'component' . DIRECTORY_SEPARATOR . 'UserInterface';
+        $path = strval(str_replace($replace, 'Apps' . DIRECTORY_SEPARATOR . $appName, strval(realpath(__DIR__))));
+        return $path;
+    }
+
+    private function determinePathToAppsCssDir(string $appName): string
+    {
+        return $this->determinePathToApp($appName) . DIRECTORY_SEPARATOR . 'css';
+    }
+
+    private function isAAppComponentsFactory(ComponentInterface $component): bool {
+        $implements = class_implements($component);
+        if(is_array($implements)) {
+            return in_array(AppComponentsFactoryInterface::class, $implements);
+        }
+        return false;
     }
 
 }

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -7,6 +7,8 @@ use DarlingDataManagementSystem\classes\component\Web\App as CoreApp;
 use DarlingDataManagementSystem\interfaces\component\OutputComponent as OutputComponentInterface;
 use DarlingDataManagementSystem\interfaces\component\UserInterface\WebUI as WebUIInterface;
 use DarlingDataManagementSystem\interfaces\component\Web\Routing\Response as ResponseInterface;
+use DarlingDataManagementSystem\interfaces\component\Factory\Factory as FactoryInterface;
+use DarlingDataManagementSystem\interfaces\component\Factory\StoredComponentFactory as StoredComponentFactoryInterface;
 use RuntimeException as PHPRuntimeException;
 
 abstract class WebUI extends ResponseUIInterface implements WebUIInterface
@@ -67,12 +69,32 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
 
     private function loadGlobalStylesheetsDefinedByRunningApps(): void
     {
-        $this->webUIOutput .= '<link rel="stylesheet" href="Apps/BuiltWebUITestApp/css/test-global-css-file.css">';
-        // foreach ($this->determineRunningAppNames as appName) {
+        foreach ($this->determineRunningAppNames() as $appName) {
+        // REF ONLY DOES NOT GO HERE: $this->webUIOutput .= '<link rel="stylesheet" href="Apps/BuiltWebUITestApp/css/test-global-css-file.css">';
         //     foreach($determineAppsGlobalStylesheetNames() as $globalStylesheetName) {
-        //         $this->webUIOutput .= '<link rel="stylesheet" href="Apps/' . $appName  . '/css/' . $globalStylesheetName . '">';
+                   $globalStylesheetName = 'foobarbaz.css';
+                   $this->webUIOutput .= '<link rel="stylesheet" href="Apps/' . $appName  . '/css/' . $globalStylesheetName . '">';
         //     }
-        // }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function determineRunningAppNames(): array
+    {
+        $runningAppNames = [];
+        $factories = $this->getRoutersComponentCrud()->readAll(
+            CoreApp::deriveAppLocationFromRequest($this->getRouter()->getRequest()),
+            StoredComponentFactoryInterface::CONTAINER
+        );
+        /**
+         * @var FactoryInterface $factory
+         */
+        foreach($factories as $factory) {
+            array_push($runningAppNames, $factory->getApp()->getName());
+        }
+        return $runningAppNames;
     }
 
     private function buildOutputWithHtmlStructure(): string
@@ -80,7 +102,7 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         /** @devNote: Always reset $this->collectiveResponseOutput when $this->buildOutputWithHtmlStructure() is called. */
         $this->collectiveResponseOutput = '';
         $this->openHtml();
-        $this->loadGlobalStylesheetsDefinedByRunningApps();
+// HERE        $this->loadGlobalStylesheetsDefinedByRunningApps();
         /**
          * @var ResponseInterface $response
          */

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -172,7 +172,6 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
                 array_push($stylesheetsToLoad, $stylesheetName);
             }
         }
-        var_dump($stylesheetsToLoad);
         return $stylesheetsToLoad;
     }
 

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -68,6 +68,11 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
     private function loadGlobalStylesheetsDefinedByRunningApps(): void
     {
         $this->webUIOutput .= '<link rel="stylesheet" href="Apps/BuiltWebUITestApp/css/test-global-css-file.css">';
+        // foreach ($this->determineRunningAppNames as appName) {
+        //     foreach($determineAppsGlobalStylesheetNames() as $globalStylesheetName) {
+        //         $this->webUIOutput .= '<link rel="stylesheet" href="Apps/' . $appName  . '/css/' . $globalStylesheetName . '">';
+        //     }
+        // }
     }
 
     private function buildOutputWithHtmlStructure(): string

--- a/core/abstractions/utility/AppBuilder.php
+++ b/core/abstractions/utility/AppBuilder.php
@@ -36,7 +36,6 @@ abstract class AppBuilder implements AppBuilderInterface
     public static function buildApp(AppComponentsFactoryInterface $appComponentsFactory): void
     {
         self::removeRegisteredComponents($appComponentsFactory);
-        self::temporaryBugFixes($appComponentsFactory);
         self::buildAppsConfiguredComponents('OutputComponents', $appComponentsFactory);
         self::buildAppsConfiguredComponents('Requests', $appComponentsFactory);
         self::buildAppsConfiguredComponents('Responses', $appComponentsFactory);
@@ -136,42 +135,6 @@ abstract class AppBuilder implements AppBuilderInterface
             $useDomain = $domain;
         }
         return AppComponentsFactory::buildDomain(($useDomain ?? 'http://localhost:8080'));
-    }
-
-    /** The following are temporary bug fixes */
-
-#########
-    private static function temporaryBugFixes(AppComponentsFactoryInterface $appComponentsFactory): void
-    {
-        /** !BUG This should not be neccessary! Fix duplicate Apps of same name type location container...*/
-        self::cleanUpDuplicateApps($appComponentsFactory->getApp()->getName(), $appComponentsFactory->getApp()->getAppDomain()->getUrl());
-        /** !BUG This should not be neccessary! Fix duplicate Apps of same name type location container...*/
-        self::cleanUpDEFAULTApps($appComponentsFactory->getApp()->getName(), $appComponentsFactory->getApp()->getAppDomain()->getUrl());
-    }
-
-    private static function cleanUpDEFAULTApps(string $appName, string $domain): void
-    {
-        $appComponentsFactory = self::getAppsAppComponentsFactory($appName, $domain);
-        foreach($appComponentsFactory->getComponentCrud()->readAll('DEFAULT', 'APP') as $component) {
-            $appComponentsFactory->getComponentCrud()->delete($component);
-        }
-    }
-
-    private static function cleanUpDuplicateApps(string $appName, string $domain): void
-    {
-        $appComponentsFactory = self::getAppsAppComponentsFactory($appName, $domain);
-        foreach($appComponentsFactory->getComponentCrud()->readAll(
-            $appComponentsFactory->getApp()->getLocation(),
-            $appComponentsFactory->getApp()->getContainer()
-        ) as $component) {
-            if(
-                $component->getName() === $appComponentsFactory->getApp()->getName()
-                &&
-                $component->getUniqueId() !== $appComponentsFactory->getApp()->getUniqueId()
-            ) {
-                $appComponentsFactory->getComponentCrud()->delete($component);
-            }
-        }
     }
 
 }


### PR DESCRIPTION
issue170: Resolved issue #170, the WebUI will now add link tags for global
stylesheets and requested stylesheets within the head tags of the output it
generates for the current Request.

Stylesheets will be "loaded" in the following circumstances:

    1. The App that defines the stylesheet was built for the current
       Request's domain and the stylesheet's name contains the word `global`.
    2. The App that defines the stylesheet was built for the current
       Request's domain and the stylesheet's name matches one of the request
       parameters defined in the current Request's query string.

All `phpunit` and `phpstan --level 8` tests are passing. All expectations defined
for the WebUI's expected output are being met.

Also tested manually with:

```
ddms --configure-app-output --for-app HelloWorld --name HelloWorld --output '<p>HelloWorld</p>'
php Apps/HelloWorld/Components.php
// created global stylesheet and a requested stylesheet named `HelloWorld`
ddms --start-server
// viewed http://localhost:8080?request=HelloWorld
```

The manuall test went as expected, both the global stylsheet and the stylsheet
named `HelloWorld` had links created for them in the within the head tags
by the WebUI.

This commit marks the resolution of issue #170.

