### PR TITLE
Composer update, now using phpstan0.12.91, also, fixed incorrect phpstan doc comment for ResponseUI::sortPositionables()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -603,16 +603,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.90",
+            "version": "0.12.91",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f0e4b56630fc3d4eb5be86606d07212ac212ede4"
+                "reference": "8226701cd228a0d63c2df995de7ab6070c69ac6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f0e4b56630fc3d4eb5be86606d07212ac212ede4",
-                "reference": "f0e4b56630fc3d4eb5be86606d07212ac212ede4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8226701cd228a0d63c2df995de7ab6070c69ac6a",
+                "reference": "8226701cd228a0d63c2df995de7ab6070c69ac6a",
                 "shasum": ""
             },
             "require": {
@@ -643,7 +643,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.90"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.91"
             },
             "funding": [
                 {
@@ -663,7 +663,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-18T07:15:38+00:00"
+            "time": "2021-07-04T15:31:48+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/core/abstractions/component/UserInterface/ResponseUI.php
+++ b/core/abstractions/component/UserInterface/ResponseUI.php
@@ -26,7 +26,7 @@ abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInter
     }
 
     /**
-     * @return array<string, PositionableInterface>
+     * @return array<PositionableInterface>
      */
     protected function sortPositionables(PositionableInterface ...$postionables): array
     {


### PR DESCRIPTION
Composer update, now using `phpstan0.12.91`, also, fixed incorrect `phpstan` doc comment for `ResponseUI::sortPositionables()`, all `phpunit` and `phpstan --level 8` tests are passing.