### PR TITLE
Housekeeping: fixed incorrect `phpstan` doc comment 

### DIFF
--- a/core/abstractions/component/UserInterface/ResponseUI.php
+++ b/core/abstractions/component/UserInterface/ResponseUI.php
@@ -26,7 +26,7 @@ abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInter
     }
 
     /**
-     * @return array<PositionableInterface>
+     * @return array<string, PositionableInterface>
      */
     protected function sortPositionables(PositionableInterface ...$postionables): array
     {
@@ -39,6 +39,7 @@ abstract class ResponseUI extends CoreOutputComponent implements ResponseUIInter
             $sorted[strval($postionable->getPosition())] = $postionable;
         }
         ksort($sorted, SORT_NUMERIC);
+        /** @var array<string, PositionableInterface> $sorted */
         return $sorted;
     }
 


### PR DESCRIPTION
Housekeeping: fixed incorrect `phpstan` doc comment for `ResponseUI::sortPositionables()`, phpstan was complaing that keys may
not be strings because of ksort(), added doc comment to make phpstan happy,
relevant array is in fact indexed by strings. All `phpunit` and `phpstan
--level 8` tests are passing.