### PR TITLE
Resolved issue #183

### DIFF
--- a/index.php
+++ b/index.php
@@ -59,4 +59,4 @@ try {
     <?php
 }
 ?>
-<!-- Powered by the Darling Cms | Currently Running App: <?php echo App::deriveNameLocationFromRequest($currentRequest); ?> -->
+<!-- Powered by the Darling Cms  | https://github.com/sevidmusic/DarlingDataManagementSystem | https://darlingdata.tech -->


### PR DESCRIPTION
Resolved issue #183, removed call to `App::deriveNameLocationFromRequest()` which was renamed to `App::deriveAppLocationFromRequest()` in merge 2c517378313d8a98b7717588b14e36c09c791613. All `phpunit` and `phpstan --level 8` tests are passing locally.