### PR TITLE
Now using darling/rig, which replaces darling/ddms

### DIFF
--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -20,8 +20,8 @@ use DarlingDataManagementSystem\interfaces\primary\Positionable as PositionableI
 use DarlingDataManagementSystem\interfaces\primary\Storable as StorableInterface;
 use DarlingDataManagementSystem\interfaces\primary\Switchable as SwitchableInterface;
 use RuntimeException as PHPRuntimeException;
-use ddms\classes\command\ConfigureAppOutput;
-use ddms\classes\ui\CommandLineUI;
+use rig\classes\command\ConfigureAppOutput;
+use rig\classes\ui\CommandLineUI;
 
 trait WebUITestTrait
 {

--- a/Tests/Unit/interfaces/utility/TestTraits/AppBuilderTestTrait.php
+++ b/Tests/Unit/interfaces/utility/TestTraits/AppBuilderTestTrait.php
@@ -343,41 +343,41 @@ trait AppBuilderTestTrait
 
     private function createTestApp(string $appName, string $domain): void
     {
-        $ddmsExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
+        $rigExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
         $this->assertTrue(
-            file_exists($ddmsExecutable),
-            'Could not create Test App because the ddms binary at ' . $ddmsExecutable . ' does not exist. Make sure composer.json requires the most recent version of ddms.'
+            file_exists($rigExecutable),
+            'Could not create Test App because the rig binary at ' . $rigExecutable . ' does not exist. Make sure composer.json requires the most recent version of rig.'
         );
         $this->assertTrue(
-            is_executable($ddmsExecutable),
-            'Could not create Test App because the ddms binary at ' . $ddmsExecutable . ' is not executable'
+            is_executable($rigExecutable),
+            'Could not create Test App because the rig binary at ' . $rigExecutable . ' is not executable'
         );
         try {
-            exec($ddmsExecutable . ' --new-app --name ' . $appName . ' --domain ' . $domain);
+            exec($rigExecutable . ' --new-app --name ' . $appName . ' --domain ' . $domain);
         } catch (\Exception $e) {
-            $this->assertFalse(true, 'Failed to create Test App because ddms --new-app failed.');
+            $this->assertFalse(true, 'Failed to create Test App because rig --new-app failed.');
         }
 
     }
 
     private function createTestOutputComponent(string $appName, string $domain): void
     {
-        $ddmsExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
+        $rigExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
         $ocName = $this->getRandomName('OutputComponent');
         $output = "$ocName Test App Output";
         $this->assertTrue(
-            file_exists($ddmsExecutable),
-            'Could not create Test App\'s OutputComponents because the ddms binary at ' . $ddmsExecutable . ' does not exist. Make sure composer.json requires the most recent version of ddms.'
+            file_exists($rigExecutable),
+            'Could not create Test App\'s OutputComponents because the rig binary at ' . $rigExecutable . ' does not exist. Make sure composer.json requires the most recent version of rig.'
         );
         $this->assertTrue(
-            is_executable($ddmsExecutable),
-            'Could not create Test App\'s OutputComponents because the ddms binary at ' . $ddmsExecutable . ' is not executable'
+            is_executable($rigExecutable),
+            'Could not create Test App\'s OutputComponents because the rig binary at ' . $rigExecutable . ' is not executable'
         );
         try {
-            exec($ddmsExecutable . ' --new-output-component --for-app ' . $appName . ' --name ' . $ocName . ' --output ' . $output . ' --container ' . $this->outputComponentContainer);
+            exec($rigExecutable . ' --new-output-component --for-app ' . $appName . ' --name ' . $ocName . ' --output ' . $output . ' --container ' . $this->outputComponentContainer);
             $this->registerExpectedOutputComponent($ocName, $output);
         } catch (\Exception $e) {
-            $this->assertFalse(true, 'Failed to create Test App\'s OutputComponents because ddms --new-output-component failed.');
+            $this->assertFalse(true, 'Failed to create Test App\'s OutputComponents because rig --new-output-component failed.');
         }
 
     }
@@ -389,22 +389,22 @@ trait AppBuilderTestTrait
 
     private function createTestRequest(string $appName, string $domain): void
     {
-        $ddmsExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
+        $rigExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
         $requestName = $this->getRandomName('Request');
         $relativeUrl = 'index.php';
         $this->assertTrue(
-            file_exists($ddmsExecutable),
-            'Could not create Test App\'s Requests because the ddms binary at ' . $ddmsExecutable . ' does not exist. Make sure composer.json requires the most recent version of ddms.'
+            file_exists($rigExecutable),
+            'Could not create Test App\'s Requests because the rig binary at ' . $rigExecutable . ' does not exist. Make sure composer.json requires the most recent version of rig.'
         );
         $this->assertTrue(
-            is_executable($ddmsExecutable),
-            'Could not create Test App\'s Requests because the ddms binary at ' . $ddmsExecutable . ' is not executable'
+            is_executable($rigExecutable),
+            'Could not create Test App\'s Requests because the rig binary at ' . $rigExecutable . ' is not executable'
         );
         try {
-            exec($ddmsExecutable . ' --new-request --for-app ' . $appName . ' --name ' . $requestName . ' --relative-url ' . '"' . $relativeUrl . '"' . ' --container ' . $this->requestContainer);
+            exec($rigExecutable . ' --new-request --for-app ' . $appName . ' --name ' . $requestName . ' --relative-url ' . '"' . $relativeUrl . '"' . ' --container ' . $this->requestContainer);
             $this->registerExpectedRequest($requestName, $relativeUrl);
         } catch (\Exception $e) {
-            $this->assertFalse(true, 'Failed to create Test App\'s Requests because ddms --new-request failed.');
+            $this->assertFalse(true, 'Failed to create Test App\'s Requests because rig --new-request failed.');
         }
 
     }
@@ -416,44 +416,44 @@ trait AppBuilderTestTrait
 
     private function createTestResponse(string $appName, string $domain): void
     {
-        $ddmsExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
+        $rigExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
         $responseName = $this->getRandomName('Response');
         $position = 4.2017;
         $this->assertTrue(
-            file_exists($ddmsExecutable),
-            'Could not create Test App\'s Responses because the ddms binary at ' . $ddmsExecutable . ' does not exist. Make sure composer.json requires the most recent version of ddms.'
+            file_exists($rigExecutable),
+            'Could not create Test App\'s Responses because the rig binary at ' . $rigExecutable . ' does not exist. Make sure composer.json requires the most recent version of rig.'
         );
         $this->assertTrue(
-            is_executable($ddmsExecutable),
-            'Could not create Test App\'s Responses because the ddms binary at ' . $ddmsExecutable . ' is not executable'
+            is_executable($rigExecutable),
+            'Could not create Test App\'s Responses because the rig binary at ' . $rigExecutable . ' is not executable'
         );
         try {
-            exec($ddmsExecutable . ' --new-response --for-app ' . $appName . ' --name ' . $responseName . ' --position ' . strval($position));
+            exec($rigExecutable . ' --new-response --for-app ' . $appName . ' --name ' . $responseName . ' --position ' . strval($position));
             $this->registerExpectedResponse($responseName, $position);
         } catch (\Exception $e) {
-            $this->assertFalse(true, 'Failed to create Test App\'s Responses because ddms --new-response failed.');
+            $this->assertFalse(true, 'Failed to create Test App\'s Responses because rig --new-response failed.');
         }
 
     }
 
     private function createTestGlobalResponse(string $appName, string $domain): void
     {
-        $ddmsExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
+        $rigExecutable = strval(realpath($this->determinePathToDdmsExecutable()));
         $responseName = $this->getRandomName('GlobalResponse');
         $position = 4.2017;
         $this->assertTrue(
-            file_exists($ddmsExecutable),
-            'Could not create Test App\'s Responses because the ddms binary at ' . $ddmsExecutable . ' does not exist. Make sure composer.json requires the most recent version of ddms.'
+            file_exists($rigExecutable),
+            'Could not create Test App\'s Responses because the rig binary at ' . $rigExecutable . ' does not exist. Make sure composer.json requires the most recent version of rig.'
         );
         $this->assertTrue(
-            is_executable($ddmsExecutable),
-            'Could not create Test App\'s Responses because the ddms binary at ' . $ddmsExecutable . ' is not executable'
+            is_executable($rigExecutable),
+            'Could not create Test App\'s Responses because the rig binary at ' . $rigExecutable . ' is not executable'
         );
         try {
-            exec($ddmsExecutable . ' --new-global-response --for-app ' . $appName . ' --name ' . $responseName . ' --position ' . strval($position));
+            exec($rigExecutable . ' --new-global-response --for-app ' . $appName . ' --name ' . $responseName . ' --position ' . strval($position));
             $this->registerExpectedGlobalResponse($responseName, $position);
         } catch (\Exception $e) {
-            $this->assertFalse(true, 'Failed to create Test App\'s Responses because ddms --new-response failed.');
+            $this->assertFalse(true, 'Failed to create Test App\'s Responses because rig --new-response failed.');
         }
 
     }
@@ -472,7 +472,7 @@ trait AppBuilderTestTrait
     {
         return str_replace(
             'Tests' . DIRECTORY_SEPARATOR . 'Unit' . DIRECTORY_SEPARATOR . 'interfaces' . DIRECTORY_SEPARATOR . 'utility' . DIRECTORY_SEPARATOR . 'TestTraits',
-            'vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'ddms' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'ddms',
+            'vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'rig',
             __DIR__
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-json": "*",
-        "darling/ddms": "^1.0",
+        "darling/rig": "^1.0",
         "darling/ddms-app-packages": "^1.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,50 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d82978db273d7661e4fe7e3642adb382",
+    "content-hash": "cb9b5f630426a8f6360c4bbf99870e04",
     "packages": [
-        {
-            "name": "darling/ddms",
-            "version": "v1.1.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sevidmusic/ddms.git",
-                "reference": "06cb1f50117aa1b99b076a9e10c66dac5de380bb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/ddms/zipball/06cb1f50117aa1b99b076a9e10c66dac5de380bb",
-                "reference": "06cb1f50117aa1b99b076a9e10c66dac5de380bb",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^0.12.79",
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "command-line-utility",
-            "autoload": {
-                "psr-4": {
-                    "ddms\\": "ddms",
-                    "tests\\": "tests"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "sevidmusic",
-                    "email": "sdmwwebsdm@gmail.com"
-                }
-            ],
-            "description": "Command line utility designed to aide in development with the Darling Data Management System",
-            "support": {
-                "issues": "https://github.com/sevidmusic/ddms/issues",
-                "source": "https://github.com/sevidmusic/ddms/tree/v1.1.6"
-            },
-            "time": "2021-07-20T16:18:20+00:00"
-        },
         {
             "name": "darling/ddms-app-packages",
             "version": "v1.8.9",
@@ -79,6 +37,48 @@
                 "source": "https://github.com/sevidmusic/ddmsAppPackages/tree/v1.8.9"
             },
             "time": "2021-07-17T22:02:22+00:00"
+        },
+        {
+            "name": "darling/rig",
+            "version": "v1.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sevidmusic/rig.git",
+                "reference": "a661c14636cb7fcc3a73dce3f5bdbd8d03ece6a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/a661c14636cb7fcc3a73dce3f5bdbd8d03ece6a6",
+                "reference": "a661c14636cb7fcc3a73dce3f5bdbd8d03ece6a6",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.79",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "command-line-utility",
+            "autoload": {
+                "psr-4": {
+                    "rig\\": "rig",
+                    "tests\\": "tests"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "sevidmusic",
+                    "email": "sdmwwebsdm@gmail.com"
+                }
+            ],
+            "description": "Command line utility designed to aide in development with the Darling Data Management System",
+            "support": {
+                "issues": "https://github.com/sevidmusic/rig/issues",
+                "source": "https://github.com/sevidmusic/rig/tree/v1.1.9"
+            },
+            "time": "2021-07-23T22:47:29+00:00"
         }
     ],
     "packages-dev": [
@@ -211,16 +211,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.11.0",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fe14cf3672a149364fb66dfe11bf6549af899f94",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -261,9 +261,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.11.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
             },
-            "time": "2021-07-03T13:36:55+00:00"
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1939,6 +1939,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {


### PR DESCRIPTION
Now using `darling/rig`, which replaces `darling/ddms`. Same code base, just a different name. 

Refactored references to `ddms` to instead refer to `rig`, which is the new name of the project formerly known as `ddms`. 

All local `phpunit` and `phpstan --level 8` tests are passing for `./core`, `./Tests`, and `./index.php`. This is related to addressing issue #196.

