### PR TITLE
Composer update, now using rig v1.2.8, and roadyAppPackages v1.1.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/rig",
-            "version": "v1.2.7",
+            "version": "v1.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/rig.git",
-                "reference": "bb606370dc98845906fc652c94ab5c3243c06e97"
+                "reference": "7cd942432f5c52ccc717772ddc9b40704c3ee007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/bb606370dc98845906fc652c94ab5c3243c06e97",
-                "reference": "bb606370dc98845906fc652c94ab5c3243c06e97",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/7cd942432f5c52ccc717772ddc9b40704c3ee007",
+                "reference": "7cd942432f5c52ccc717772ddc9b40704c3ee007",
                 "shasum": ""
             },
             "require-dev": {
@@ -44,22 +44,22 @@
             "description": "Command line utility designed to aide in development with Roady",
             "support": {
                 "issues": "https://github.com/sevidmusic/rig/issues",
-                "source": "https://github.com/sevidmusic/rig/tree/v1.2.7"
+                "source": "https://github.com/sevidmusic/rig/tree/v1.2.8"
             },
-            "time": "2021-08-13T15:57:13+00:00"
+            "time": "2021-08-14T19:49:37+00:00"
         },
         {
             "name": "darling/roady-app-packages",
-            "version": "v1.1.2",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/roadyAppPackages.git",
-                "reference": "251a3ecf8f0d6d223ecce24c21dc6c2846e5308b"
+                "reference": "9c3c53791d6ed2a9d6f6e6469348b38a82754258"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/251a3ecf8f0d6d223ecce24c21dc6c2846e5308b",
-                "reference": "251a3ecf8f0d6d223ecce24c21dc6c2846e5308b",
+                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/9c3c53791d6ed2a9d6f6e6469348b38a82754258",
+                "reference": "9c3c53791d6ed2a9d6f6e6469348b38a82754258",
                 "shasum": ""
             },
             "type": "library",
@@ -70,9 +70,9 @@
             "description": "A collection of App packages that can be made into Roady Apps.",
             "support": {
                 "issues": "https://github.com/sevidmusic/roadyAppPackages/issues",
-                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.2"
+                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.3"
             },
-            "time": "2021-08-13T05:43:46+00:00"
+            "time": "2021-08-14T17:19:49+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Composer update, now using [rig v1.2.8](https://github.com/sevidmusic/rig/releases/tag/v1.2.8), and [roadyAppPackages v1.1.3](https://github.com/sevidmusic/roadyAppPackages/releases/tag/v1.1.3)