### PR TITLE
Composer update, now using rig v1.3.1 and roadyAppPackages v1.1.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/rig",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/rig.git",
-                "reference": "34bc3ccec8c5b8521a303eae88f41d96f8e30375"
+                "reference": "d6f6d363bf6a4e01ef87c7dcc7376f97feea8908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/34bc3ccec8c5b8521a303eae88f41d96f8e30375",
-                "reference": "34bc3ccec8c5b8521a303eae88f41d96f8e30375",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/d6f6d363bf6a4e01ef87c7dcc7376f97feea8908",
+                "reference": "d6f6d363bf6a4e01ef87c7dcc7376f97feea8908",
                 "shasum": ""
             },
             "require-dev": {
@@ -44,22 +44,22 @@
             "description": "Command line utility designed to aide in development with Roady",
             "support": {
                 "issues": "https://github.com/sevidmusic/rig/issues",
-                "source": "https://github.com/sevidmusic/rig/tree/v1.3.0"
+                "source": "https://github.com/sevidmusic/rig/tree/v1.3.1"
             },
-            "time": "2021-08-17T01:53:30+00:00"
+            "time": "2021-08-17T04:56:48+00:00"
         },
         {
             "name": "darling/roady-app-packages",
-            "version": "v1.1.5",
+            "version": "v1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/roadyAppPackages.git",
-                "reference": "835e1749f1d67c49d26a9f85305d76105569cd41"
+                "reference": "89d5b75315ef8742ca62423abf2c4360ec27e273"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/835e1749f1d67c49d26a9f85305d76105569cd41",
-                "reference": "835e1749f1d67c49d26a9f85305d76105569cd41",
+                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/89d5b75315ef8742ca62423abf2c4360ec27e273",
+                "reference": "89d5b75315ef8742ca62423abf2c4360ec27e273",
                 "shasum": ""
             },
             "type": "library",
@@ -70,9 +70,9 @@
             "description": "A collection of App packages that can be made into Roady Apps.",
             "support": {
                 "issues": "https://github.com/sevidmusic/roadyAppPackages/issues",
-                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.5"
+                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.6"
             },
-            "time": "2021-08-17T01:14:17+00:00"
+            "time": "2021-08-17T04:57:36+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Composer update, now using [rig v1.3.1](https://github.com/sevidmusic/rig/releases/tag/v1.3.1) and [roadyAppPackages v1.1.6](https://github.com/sevidmusic/roadyAppPackages/releases/tag/v1.1.6)