### PR TITLE
Composer update, now using rig v1.3.2 and roadyAppPackages v1.1.7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/rig",
-            "version": "v1.3.1",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/rig.git",
-                "reference": "d6f6d363bf6a4e01ef87c7dcc7376f97feea8908"
+                "reference": "f586ff8bd01ee43ab87612179b280a8673eda1ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/d6f6d363bf6a4e01ef87c7dcc7376f97feea8908",
-                "reference": "d6f6d363bf6a4e01ef87c7dcc7376f97feea8908",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/f586ff8bd01ee43ab87612179b280a8673eda1ee",
+                "reference": "f586ff8bd01ee43ab87612179b280a8673eda1ee",
                 "shasum": ""
             },
             "require-dev": {
@@ -44,22 +44,22 @@
             "description": "Command line utility designed to aide in development with Roady",
             "support": {
                 "issues": "https://github.com/sevidmusic/rig/issues",
-                "source": "https://github.com/sevidmusic/rig/tree/v1.3.1"
+                "source": "https://github.com/sevidmusic/rig/tree/v1.3.2"
             },
-            "time": "2021-08-17T04:56:48+00:00"
+            "time": "2021-08-19T06:23:28+00:00"
         },
         {
             "name": "darling/roady-app-packages",
-            "version": "v1.1.6",
+            "version": "v1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/roadyAppPackages.git",
-                "reference": "89d5b75315ef8742ca62423abf2c4360ec27e273"
+                "reference": "3823cdbe4e8d1a12807988607caf0a0239c5a358"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/89d5b75315ef8742ca62423abf2c4360ec27e273",
-                "reference": "89d5b75315ef8742ca62423abf2c4360ec27e273",
+                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/3823cdbe4e8d1a12807988607caf0a0239c5a358",
+                "reference": "3823cdbe4e8d1a12807988607caf0a0239c5a358",
                 "shasum": ""
             },
             "type": "library",
@@ -70,9 +70,9 @@
             "description": "A collection of App packages that can be made into Roady Apps.",
             "support": {
                 "issues": "https://github.com/sevidmusic/roadyAppPackages/issues",
-                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.6"
+                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.7"
             },
-            "time": "2021-08-17T04:57:36+00:00"
+            "time": "2021-08-19T06:25:43+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Composer update, now using [rig v1.3.2](https://github.com/sevidmusic/rig/releases/tag/v1.3.2) and [roadyAppPackages v1.1.7](https://github.com/sevidmusic/roadyAppPackages/releases/tag/v1.1.7)