### PR TITLE
Composer update, now using rig v1.3.4 and roadyAppPackages v1.1.9

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/rig",
-            "version": "v1.3.3",
+            "version": "v1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/rig.git",
-                "reference": "96400b2da396a57611d8f4ae9b650d2e191c7267"
+                "reference": "ed45836ab4e098fbb2bce38b6e9aa03ac7b1bc5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/96400b2da396a57611d8f4ae9b650d2e191c7267",
-                "reference": "96400b2da396a57611d8f4ae9b650d2e191c7267",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/ed45836ab4e098fbb2bce38b6e9aa03ac7b1bc5a",
+                "reference": "ed45836ab4e098fbb2bce38b6e9aa03ac7b1bc5a",
                 "shasum": ""
             },
             "require-dev": {
@@ -44,22 +44,22 @@
             "description": "Command line utility designed to aide in development with Roady",
             "support": {
                 "issues": "https://github.com/sevidmusic/rig/issues",
-                "source": "https://github.com/sevidmusic/rig/tree/v1.3.3"
+                "source": "https://github.com/sevidmusic/rig/tree/v1.3.4"
             },
-            "time": "2021-08-19T17:44:46+00:00"
+            "time": "2021-08-19T23:13:54+00:00"
         },
         {
             "name": "darling/roady-app-packages",
-            "version": "v1.1.8",
+            "version": "v1.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/roadyAppPackages.git",
-                "reference": "b8af0c33f8963f461702688d1c392f417162ea90"
+                "reference": "366fbb5d1034e81d9f1482c62661c17543de5704"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/b8af0c33f8963f461702688d1c392f417162ea90",
-                "reference": "b8af0c33f8963f461702688d1c392f417162ea90",
+                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/366fbb5d1034e81d9f1482c62661c17543de5704",
+                "reference": "366fbb5d1034e81d9f1482c62661c17543de5704",
                 "shasum": ""
             },
             "type": "library",
@@ -70,9 +70,9 @@
             "description": "A collection of App packages that can be made into Roady Apps.",
             "support": {
                 "issues": "https://github.com/sevidmusic/roadyAppPackages/issues",
-                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.8"
+                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.1.9"
             },
-            "time": "2021-08-19T17:38:21+00:00"
+            "time": "2021-08-19T23:10:50+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Composer update, now using [rig v1.3.4](https://github.com/sevidmusic/rig/releases/tag/v1.3.4) and [roadyAppPackages v1.1.9](https://github.com/sevidmusic/roadyAppPackages/releases/tag/v1.1.9)