### PR TITLE
Composer update, now using rig v1.4.5 and roadyAppPackage v1.2.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/rig",
-            "version": "v1.4.4",
+            "version": "v1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/rig.git",
-                "reference": "3a11664fe58d558e7e8a4aa0e416825ae32f9029"
+                "reference": "5417bddfe99aeeea2712068acfd735da3cb168f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/3a11664fe58d558e7e8a4aa0e416825ae32f9029",
-                "reference": "3a11664fe58d558e7e8a4aa0e416825ae32f9029",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/5417bddfe99aeeea2712068acfd735da3cb168f9",
+                "reference": "5417bddfe99aeeea2712068acfd735da3cb168f9",
                 "shasum": ""
             },
             "require-dev": {
@@ -44,22 +44,22 @@
             "description": "Command line utility designed to aide in development with Roady",
             "support": {
                 "issues": "https://github.com/sevidmusic/rig/issues",
-                "source": "https://github.com/sevidmusic/rig/tree/v1.4.4"
+                "source": "https://github.com/sevidmusic/rig/tree/v1.4.5"
             },
-            "time": "2021-09-03T07:13:25+00:00"
+            "time": "2021-09-05T20:40:53+00:00"
         },
         {
             "name": "darling/roady-app-packages",
-            "version": "v1.2.5",
+            "version": "v1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/roadyAppPackages.git",
-                "reference": "345249266301a97334e31515b34326f8df2d8b4c"
+                "reference": "e75e27004c351ca0214736b4736e569c3a9f142f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/345249266301a97334e31515b34326f8df2d8b4c",
-                "reference": "345249266301a97334e31515b34326f8df2d8b4c",
+                "url": "https://api.github.com/repos/sevidmusic/roadyAppPackages/zipball/e75e27004c351ca0214736b4736e569c3a9f142f",
+                "reference": "e75e27004c351ca0214736b4736e569c3a9f142f",
                 "shasum": ""
             },
             "type": "library",
@@ -70,9 +70,9 @@
             "description": "A collection of App packages that can be made into Roady Apps.",
             "support": {
                 "issues": "https://github.com/sevidmusic/roadyAppPackages/issues",
-                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.2.5"
+                "source": "https://github.com/sevidmusic/roadyAppPackages/tree/v1.2.6"
             },
-            "time": "2021-08-30T18:34:19+00:00"
+            "time": "2021-09-05T20:36:24+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Composer update, now using [rig v1.4.5](https://github.com/sevidmusic/rig/releases/tag/v1.4.5) and [roadyAppPackage v1.2.6](https://github.com/sevidmusic/roadyAppPackages/releases/tag/v1.2.6)