### PR TITLE
Composer update, now using rig v1.6.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/rig",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/rig.git",
-                "reference": "d13d487aed38ad2584bf558ce27057f5b27ba51f"
+                "reference": "8cad6d9bb022155a519f0b3ab05ec6a8cdaa1bb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/d13d487aed38ad2584bf558ce27057f5b27ba51f",
-                "reference": "d13d487aed38ad2584bf558ce27057f5b27ba51f",
+                "url": "https://api.github.com/repos/sevidmusic/rig/zipball/8cad6d9bb022155a519f0b3ab05ec6a8cdaa1bb4",
+                "reference": "8cad6d9bb022155a519f0b3ab05ec6a8cdaa1bb4",
                 "shasum": ""
             },
             "require-dev": {
@@ -44,9 +44,9 @@
             "description": "Command line utility designed to aide in development with Roady",
             "support": {
                 "issues": "https://github.com/sevidmusic/rig/issues",
-                "source": "https://github.com/sevidmusic/rig/tree/v1.6.0"
+                "source": "https://github.com/sevidmusic/rig/tree/v1.6.1"
             },
-            "time": "2021-10-16T05:16:23+00:00"
+            "time": "2021-10-16T21:53:33+00:00"
         },
         {
             "name": "darling/roady-app-packages",


### PR DESCRIPTION
Composer update, now using [rig v1.6.1](https://github.com/sevidmusic/rig/releases/tag/v1.6.1)