### PR TITLE
Working on issues #299, #310, and #302

### DIFF
--- a/Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php
+++ b/Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php
@@ -99,7 +99,7 @@ trait ComponentCrudTestTrait
      *
      * @return void
      */
-    private function turnCrudToTestOn(): void
+    private function setComponentCrudToTestsStateToTrue(): void
     {
         if ($this->componentCrudToTest()->getState() === false) {
             $this->componentCrudToTest()->switchState();
@@ -192,7 +192,7 @@ trait ComponentCrudTestTrait
         $this->componentCrudToTest()->create(
             $this->componentCrudToTest()
         );
-        $this->turnCrudOff();
+        $this->setComponentCrudToTestsStateToFalse();
         $this->assertEquals(
             'MOCKCOMPONENT',
             $this->getStoredComponent()->getName(),
@@ -210,7 +210,7 @@ trait ComponentCrudTestTrait
         );
     }
 
-    private function turnCrudOff(): void
+    private function setComponentCrudToTestsStateToFalse(): void
     {
         if ($this->componentCrudToTest()->getState() === true) {
             $this->componentCrudToTest()->switchState();
@@ -223,7 +223,7 @@ trait ComponentCrudTestTrait
         $this->componentCrudToTest()->create(
             $this->componentCrudToTest()
         );
-        $this->turnCrudOff();
+        $this->setComponentCrudToTestsStateToFalse();
         $this->assertFalse(
             $this->componentCrudToTest()->update(
                 $this->componentCrudToTest(),
@@ -231,7 +231,7 @@ trait ComponentCrudTestTrait
             ),
             'update() must return false if state is false.'
         );
-        $this->turnCrudToTestOn();
+        $this->setComponentCrudToTestsStateToTrue();
         $this->assertNotEquals(
             $this->getStoredComponent()->getUniqueId(),
             $component->getUniqueId(),
@@ -249,14 +249,14 @@ trait ComponentCrudTestTrait
         $this->componentCrudToTest()->create(
             $this->componentCrudToTest()
         );
-        $this->turnCrudOff();
+        $this->setComponentCrudToTestsStateToFalse();
         $this->assertFalse(
             $this->componentCrudToTest()->delete(
                 $this->componentCrudToTest()
             ),
             'delete() must return false if state is false.'
         );
-        $this->turnCrudToTestOn();
+        $this->setComponentCrudToTestsStateToTrue();
         $this->assertEquals(
             $this->getStoredComponent()->getUniqueId(),
             $this->componentCrudToTest()->getUniqueId(),
@@ -266,14 +266,14 @@ trait ComponentCrudTestTrait
 
     public function testCreateReturnsFalseAndDoesNotCreateComponentIfStateIsFalse(): void
     {
-        $this->turnCrudOff();
+        $this->setComponentCrudToTestsStateToFalse();
         $this->assertFalse(
             $this->componentCrudToTest()->create(
                 $this->componentCrudToTest()
             ),
             'create() must return false if state is false.'
         );
-        $this->turnCrudToTestOn();
+        $this->setComponentCrudToTestsStateToTrue();
         $this->assertNotEquals(
             $this->componentCrudToTest()->getUniqueId(),
             $this->getStoredComponent()->getUniqueId(),
@@ -283,7 +283,7 @@ trait ComponentCrudTestTrait
 
     public function testReadAllReturnsAnEmptyArrayIfStateIsFalse(): void
     {
-        $this->turnCrudOff();
+        $this->setComponentCrudToTestsStateToFalse();
         $this->assertEmpty(
             $this->componentCrudToTest()->readAll(
                 $this->componentCrudToTest()->getLocation(),

--- a/Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php
+++ b/Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php
@@ -2,109 +2,168 @@
 
 namespace UnitTests\interfaces\component\Crud\TestTraits;
 
-use roady\interfaces\component\Component as ComponentInterface;
-use roady\interfaces\component\Crud\ComponentCrud as ComponentCrudInterface;
-use roady\interfaces\component\Driver\Storage\StorageDriver as StandardStorageDriverInterface;
-use roady\interfaces\primary\Storable as StorableInterface;
 use RuntimeException;
+use roady\interfaces\component\Component;
+use roady\interfaces\component\Crud\ComponentCrud;
+use roady\interfaces\component\Driver\Storage\StorageDriver;
+use roady\interfaces\primary\Storable;
 
+/**
+ * The ComponentCrudTestTrait defines tests for implementations of
+ * the ComponentCrud interface.
+ */
 trait ComponentCrudTestTrait
 {
 
-    private ComponentCrudInterface $componentCrud;
+    /**
+     * @var ComponentCrud $componentCrudToTest An instance of a
+     *                                         ComponentCrud
+     *                                         implementation
+     *                                         to test.
+     */
+    private ComponentCrud $componentCrudToTest;
 
-    public function testStorageDriverIsSetAndIsAStorageDriverPostInstantiation(): void
+    /**
+     * Test that exporting a ComponentCrud's storageDriver
+     * returns an object instance that is an implementation of the
+     * StorageDriver interface.
+     *
+     * @return void
+     */
+    public function testExportStorageDriverReturnsAStorageDriver(): void
     {
         $classImplements = class_implements(
-            $this->getComponentCrudStorageDriver(),
+            $this->componentCrudToTest()->export()['storageDriver'],
         );
         $this->assertTrue(
             in_array(
-                StandardStorageDriverInterface::class,
+                StorageDriver::class,
                 (is_array($classImplements) ? $classImplements : [])
-            )
+            ),
+            'Exporting a ComponentCrud\'s StorageDriver via' .
+            'ComponentCrud->export()[\'storageDriver\']' .
+            'must return an object that implements the' .
+            StorageDriver::class .
+            ' interface'
         );
     }
 
-    private function getComponentCrudStorageDriver(): StandardStorageDriverInterface
+    /**
+     * Return the ComponentCrud implementation instance to be
+     * tested.
+     *
+     * @return ComponentCrud
+     */
+    public function componentCrudToTest(): ComponentCrud
     {
-        return $this->getComponentCrud()->export()['storageDriver'];
+        return $this->componentCrudToTest;
     }
 
-    public function getComponentCrud(): ComponentCrudInterface
-    {
-        return $this->componentCrud;
-    }
-
+    /**
+     * Set the ComponentCrud implementation instance to be tested.
+     *
+     * @return void
+     */
     public function setComponentCrud(
-        ComponentCrudInterface $componentCrud
+        ComponentCrud $componentCrudToTest
     ): void
     {
-        $this->componentCrud = $componentCrud;
+        $this->componentCrudToTest = $componentCrudToTest;
     }
 
+    /**
+     * @todo ComponentCrud: Refactor appropriate test methods,
+     *                      and implement missing tests methods.
+     *
+     * Refactor testCreateReturnsTrue() to be
+     * testCreateReturnsTrueIfComponentWasCreated()
+     *
+     * @see https://github.com/sevidmusic/roady/issues/315
+     *
+     */
     public function testCreateReturnsTrue(): void
     {
-        $this->turnCrudOn();
         $this->assertTrue(
-            $this->getComponentCrud()->create(
-                $this->getComponentCrud()
+            $this->componentCrudToTest()->create(
+                $this->componentCrudToTest()
             )
+        );
+        $this->componentCrudToTest()->delete(
+            $this->componentCrudToTest()
         );
     }
 
-    private function turnCrudOn(): void
+    /**
+     * Switch the state of the ComponentCrud currently being tested
+     * to true if it is false.
+     *
+     * @return void
+     */
+    private function turnCrudToTestOn(): void
     {
-        if ($this->getComponentCrud()->getState() === false) {
-            $this->getComponentCrud()->switchState();
+        if ($this->componentCrudToTest()->getState() === false) {
+            $this->componentCrudToTest()->switchState();
         }
     }
 
+    /**
+     * Test that read() returns the specified Component.
+     *
+     * @return void
+     */
     public function testReadReturnsSpecifiedComponent(): void
     {
-        $this->turnCrudOn();
-        $this->getComponentCrud()->create($this->getComponentCrud());
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
+        );
         $this->assertEquals(
-            $this->getComponentCrud()->getUniqueId(),
-            $this->getStoredComponent()->getUniqueId()
+            $this->componentCrudToTest()->getUniqueId(),
+            $this->componentCrudToTest()->read(
+                $this->componentCrudToTest()
+            )->getUniqueId()
+        );
+        $this->componentCrudToTest()->delete(
+            $this->componentCrudToTest()
         );
     }
 
-    private function getStoredComponent(): ComponentInterface
+    /**
+     * Return the ComponentCrud to test from storage if it exists.
+     *
+     * @return Component
+     */
+    private function getStoredComponent(): Component
     {
-        return $this->getComponentCrud()->read(
-            $this->getComponentCrudStorable()
+        return $this->componentCrudToTest()->read(
+            $this->componentCrudToTest()
         );
-    }
-
-    private function getComponentCrudStorable(): StorableInterface
-    {
-        return $this->getComponentCrud()->export()['storable'];
     }
 
     public function testDeleteRemovesSpecifiedComponent(): void
     {
-        $this->getComponentCrud()->create(
-            $this->getComponentCrud()
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
         );
-        $this->getComponentCrud()->delete(
-            $this->getComponentCrudStorable()
+        $this->componentCrudToTest()->delete(
+            $this->componentCrudToTest()
         );
         $this->assertNotEquals(
-            $this->getComponentCrud()->getUniqueId(),
-            $this->getStoredComponent()->getUniqueId()
+            $this->componentCrudToTest()->getUniqueId(),
+            $this->componentCrudToTest()->read(
+                $this->componentCrudToTest()
+            )->getUniqueId()
         );
     }
 
     public function testUpdateUpdatesSpecifiedComponent(): void
     {
         $standardComponent = $this->getStoredComponent();
-        $this->getComponentCrud()->create(
-            $this->getComponentCrud()
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
         );
         $storedComponent = $this->getStoredComponent();
-        $this->getComponentCrud()->update(
-            $this->getComponentCrudStorable(),
+        $this->componentCrudToTest()->update(
+            $this->componentCrudToTest(),
             $standardComponent
         );
         $this->assertNotEquals(
@@ -116,23 +175,22 @@ trait ComponentCrudTestTrait
 
     public function testReadAllReturnsArrayOfComponentsStoredInSpecifiedContainerAtSpecifiedLocation(): void
     {
-        $this->turnCrudOn();
-        $this->getComponentCrud()->create(
-            $this->getComponentCrud()
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
         );
-        $components = $this->getComponentCrud()->readAll(
-            $this->getComponentCrud()->getLocation(),
-            $this->getComponentCrud()->getContainer()
+        $components = $this->componentCrudToTest()->readAll(
+            $this->componentCrudToTest()->getLocation(),
+            $this->componentCrudToTest()->getContainer()
         );
         $this->assertTrue(in_array(
-            $this->getComponentCrud(), $components)
+            $this->componentCrudToTest(), $components)
         );
     }
 
     public function testReadReturnsMockComponentInstanceIfStateIsFalse(): void
     {
-        $this->getComponentCrud()->create(
-            $this->getComponentCrud()
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
         );
         $this->turnCrudOff();
         $this->assertEquals(
@@ -154,27 +212,26 @@ trait ComponentCrudTestTrait
 
     private function turnCrudOff(): void
     {
-        if ($this->getComponentCrud()->getState() === true) {
-            $this->getComponentCrud()->switchState();
+        if ($this->componentCrudToTest()->getState() === true) {
+            $this->componentCrudToTest()->switchState();
         }
     }
 
     public function testUpdateReturnsFalseAndDoesNotUpdateComponentIfStateIsFalse(): void
     {
-        $this->turnCrudOn();
         $component = $this->getStoredComponent();
-        $this->getComponentCrud()->create(
-            $this->getComponentCrud()
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
         );
         $this->turnCrudOff();
         $this->assertFalse(
-            $this->getComponentCrud()->update(
-                $this->getComponentCrudStorable(),
+            $this->componentCrudToTest()->update(
+                $this->componentCrudToTest(),
                 $component
             ),
             'update() must return false if state is false.'
         );
-        $this->turnCrudOn();
+        $this->turnCrudToTestOn();
         $this->assertNotEquals(
             $this->getStoredComponent()->getUniqueId(),
             $component->getUniqueId(),
@@ -182,28 +239,27 @@ trait ComponentCrudTestTrait
         );
         $this->assertEquals(
             $this->getStoredComponent()->getUniqueId(),
-            $this->getComponentCrud()->getUniqueId(),
+            $this->componentCrudToTest()->getUniqueId(),
             'update() must not update component if state is false.'
         );
     }
 
     public function testDeleteReturnsFalseAndDoesNotDeleteComponentIfStateIsFalse(): void
     {
-        $this->turnCrudOn();
-        $this->getComponentCrud()->create(
-            $this->getComponentCrud()
+        $this->componentCrudToTest()->create(
+            $this->componentCrudToTest()
         );
         $this->turnCrudOff();
         $this->assertFalse(
-            $this->getComponentCrud()->delete(
-                $this->getComponentCrudStorable()
+            $this->componentCrudToTest()->delete(
+                $this->componentCrudToTest()
             ),
             'delete() must return false if state is false.'
         );
-        $this->turnCrudOn();
+        $this->turnCrudToTestOn();
         $this->assertEquals(
             $this->getStoredComponent()->getUniqueId(),
-            $this->getComponentCrud()->getUniqueId(),
+            $this->componentCrudToTest()->getUniqueId(),
             'delete() must not update component if state is false.'
         );
     }
@@ -212,14 +268,14 @@ trait ComponentCrudTestTrait
     {
         $this->turnCrudOff();
         $this->assertFalse(
-            $this->getComponentCrud()->create(
-                $this->getComponentCrud()
+            $this->componentCrudToTest()->create(
+                $this->componentCrudToTest()
             ),
             'create() must return false if state is false.'
         );
-        $this->turnCrudOn();
+        $this->turnCrudToTestOn();
         $this->assertNotEquals(
-            $this->getComponentCrud()->getUniqueId(),
+            $this->componentCrudToTest()->getUniqueId(),
             $this->getStoredComponent()->getUniqueId(),
             'create() must not update component if state is false.'
         );
@@ -229,9 +285,9 @@ trait ComponentCrudTestTrait
     {
         $this->turnCrudOff();
         $this->assertEmpty(
-            $this->getComponentCrud()->readAll(
-                $this->getComponentCrud()->getLocation(),
-                $this->getComponentCrud()->getContainer()
+            $this->componentCrudToTest()->readAll(
+                $this->componentCrudToTest()->getLocation(),
+                $this->componentCrudToTest()->getContainer()
             ),
             'readAll() must return an empty array if state is false.'
         );
@@ -240,7 +296,7 @@ trait ComponentCrudTestTrait
     public function testStorageDriverIsOnUponInstantiation(): void
     {
         $this->assertTrue(
-            $this->getComponentCrud()
+            $this->componentCrudToTest()
                  ->export()['storageDriver']
                  ->getState(),
              'The storage driver\'s state must be true or the' .
@@ -252,7 +308,7 @@ trait ComponentCrudTestTrait
     protected function setComponentCrudParentTestInstances(): void
     {
         $this->setSwitchableComponent(
-            $this->getComponentCrud()
+            $this->componentCrudToTest()
         );
         $this->setSwitchableComponentParentTestInstances();
     }
@@ -260,7 +316,7 @@ trait ComponentCrudTestTrait
     public function testReadByNameAndTypeThrowsRuntimeExceptionIfAMatchIsNotFound(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->getComponentCrud()->readByNameAndType(
+        $this->componentCrudToTest()->readByNameAndType(
             strval(rand(1000, 9999)),
             strval(rand(1000, 9999)),
             strval(rand(1000, 9999)),
@@ -272,7 +328,7 @@ trait ComponentCrudTestTrait
     public function testReadByNameAndTypeReturnsComponentWhoseNameLoctionAndContainerAreDEFAULTIfAMatchIsNotFound(): void
     {
         $this->expectException(RuntimeException::class);
-        $component = $this->getComponentCrud()->readByNameAndType(
+        $component = $this->componentCrudToTest()->readByNameAndType(
             strval(rand(1000, 9999)),
             strval(rand(1000, 9999)),
             strval(rand(1000, 9999)),
@@ -285,7 +341,7 @@ trait ComponentCrudTestTrait
 
     public function testReadByNameAndTypeReturnsComponentWhoseNameAndTypeMatchSpecifiedNameAndTypeIfAStoredComponentWithMatchngNameAndTypeExists(): void
     {
-        $crud = $this->getComponentCrud();
+        $crud = $this->componentCrudToTest();
         $crud->create($crud);
         $component = $crud->readByNameAndType(
             $crud->getName(),

--- a/Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php
+++ b/Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php
@@ -62,6 +62,10 @@ trait ComponentCrudTestTrait
     /**
      * Set the ComponentCrud implementation instance to be tested.
      *
+     * @param ComponentCrud $componentCrudToTest The ComponentCrud
+     *                                           implementation
+     *                                           instance to be
+     *                                           tested.
      * @return void
      */
     public function setComponentCrud(
@@ -88,14 +92,11 @@ trait ComponentCrudTestTrait
                 $this->componentCrudToTest()
             )
         );
-        $this->componentCrudToTest()->delete(
-            $this->componentCrudToTest()
-        );
     }
 
     /**
      * Switch the state of the ComponentCrud currently being tested
-     * to true if it is false.
+     * to true.
      *
      * @return void
      */
@@ -122,9 +123,6 @@ trait ComponentCrudTestTrait
                 $this->componentCrudToTest()
             )->getUniqueId()
         );
-        $this->componentCrudToTest()->delete(
-            $this->componentCrudToTest()
-        );
     }
 
     /**
@@ -139,6 +137,10 @@ trait ComponentCrudTestTrait
         );
     }
 
+    /** Test that delete() removes the specified Component.
+     *
+     * @return void
+     */
     public function testDeleteRemovesSpecifiedComponent(): void
     {
         $this->componentCrudToTest()->create(
@@ -154,6 +156,13 @@ trait ComponentCrudTestTrait
             )->getUniqueId()
         );
     }
+
+    /**
+     * @here
+     * Test that update() updates the specified Component.
+     *
+     * @return void
+     */
 
     public function testUpdateUpdatesSpecifiedComponent(): void
     {
@@ -357,6 +366,12 @@ trait ComponentCrudTestTrait
             $crud->getType(),
             $component->getType()
         );
-        $crud->delete($crud);
+    }
+
+    public function tearDown(): void
+    {
+        $this->componentcrudToTest()->delete(
+            $this->componentcrudToTest()
+        );
     }
 }


### PR DESCRIPTION
Working on issues #299:
- Housekeeping/code clean up.
- Renamed` turnCrudOff()` method to `setComponentCrudToTestsStateToFalse()`, and `turnCrudToTestOn()` to `setComponentCrudToTestsStateToTrue()` in `Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php`. These new names more clearly articulate each methods purpose.

Working on addressing issue #310: 
- defined `tearDown()` method in in `Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php`, which will delete the `ComponentCrud` to test from storage if it was created during a test. 
 
Working on issue #302:
- Renamed `getComponentCrud()` in `Tests/Unit/interfaces/component/Crud/TestTraits/ComponentCrudTestTrait.php` to `componentCrudToTest()`
