### PR TITLE
Roady1650348913

### DIFF
--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php
@@ -69,10 +69,29 @@ trait ResponseUITestTrait
                 self::getTestComponentContainer()
             ),
             new CoreSwitchable(),
-            new CorePositionable(rand(100, 999)),
+            new CorePositionable(rand(-10, 100)),
         );
         $outputComponent->import([
-            'output' => PHP_EOL . 'OC ID: ' . $outputComponent->getUniqueId() . PHP_EOL . 'OC NAME: ' . $outputComponent->getName() . PHP_EOL
+            'output' =>
+                PHP_EOL .
+                'ResponseUITestTrait: Test OutputComponent Position: ' .
+                $outputComponent->getPosition() .
+                PHP_EOL .
+                'ResponseUITestTrait: Test OutputComponent Name: ' .
+                $outputComponent->getName() .
+                PHP_EOL .
+                'ResponseUITestTrait: Test OutputComponent Id: ' .
+                $outputComponent->getUniqueId() .
+                PHP_EOL .
+                'ResponseUITestTrait: Test OutputComponent Location: ' .
+                $outputComponent->getLocation() .
+                PHP_EOL .
+                'ResponseUITestTrait: Test OutputComponent Container: ' .
+                $outputComponent->getContainer() .
+                PHP_EOL .
+                'ResponseUITestTrait: Test OutputComponent Type: ' .
+                $outputComponent->getType() .
+                PHP_EOL
         ]);
         return $outputComponent;
     }
@@ -86,7 +105,7 @@ trait ResponseUITestTrait
                 ResponseInterface::RESPONSE_CONTAINER,
             ),
             new CoreSwitchable(),
-            new CorePositionable(rand(0,100)),
+            new CorePositionable(rand(-10,10)),
         );
         $request = self::getRequest();
         self::getComponentCrud()->create($request);
@@ -102,7 +121,9 @@ trait ResponseUITestTrait
 
     public static function setUpBeforeClass(): void
     {
-        self::getComponentCrud()->create(self::generateTestResponse());
+        for($i=0; $i <= rand(10, 20); $i++) {
+            self::getComponentCrud()->create(self::generateTestResponse());
+        }
     }
 
     /**
@@ -158,16 +179,6 @@ trait ResponseUITestTrait
             new CorePositionable(),
             self::getRouter()
         ];
-    }
-
-    public function testGetRouterTestMethodReturnsARouterImplemnetationInstance(): void
-    {
-        $this->assertTrue(
-            $this->isProperImplementation(
-                RouterInterface::class,
-                self::getRouter()
-            )
-        );
     }
 
     public static function getRouter(): RouterInterface

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -373,7 +373,7 @@ trait WebUITestTrait
             ),
             new Switchable()
         );
-        $request->import(['url' => './?request=' . self::$requestedStylesheetNameA . '&request=' . self::$requestedStylesheetNameB]);
+        $request->import(['url' => self::$testDomain . '/?request=' . self::$requestedStylesheetNameA . '&request=' . self::$requestedStylesheetNameB]);
         return $request;
     }
 

--- a/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
+++ b/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php
@@ -92,6 +92,7 @@ trait WebUITestTrait
     private string $doctype = '<!DOCTYPE html>' . PHP_EOL;
     private string $openHtml = '<html lang="en">' . PHP_EOL;
     private string $openHead = '<head>' . PHP_EOL;
+    private string $viewport = '<meta name="viewport" content="width=device-width, initial-scale=1.0">';
     private string $titleSprint = PHP_EOL . '<title>%s</title>' . PHP_EOL;
     private string $closeHead = '</head>' . PHP_EOL;
     private string $openBody = '<body>' . PHP_EOL;
@@ -335,7 +336,8 @@ trait WebUITestTrait
             $this->doctype .
             $this->openHtml .
             $this->openHead .
-            $this->expectedTitle();
+            $this->expectedTitle() .
+            $this->viewport;
         $expectedResponses = $this->expectedResponses();
         $sortedResponses = $this->sortPositionables(...$expectedResponses);
         error_log(strval(count($sortedResponses)));

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -18,8 +18,8 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
     private const DOCTYPE = '<!DOCTYPE html>' . PHP_EOL;
     private const OPEN_HTML = '<html lang="en">' . PHP_EOL;
     private const OPEN_HEAD = '<head>' . PHP_EOL;
-    private const OPEN_TITLE = '<title>';
-    private const CLOSE_TITLE = '</title>';
+    private const VIEWPORT = '<meta name="viewport" content="width=device-width, initial-scale=1.0">';
+    private string $titleSprint = PHP_EOL . '<title>%s</title>' . PHP_EOL;
     private const CLOSE_HEAD = '</head>' . PHP_EOL;
     private const OPEN_BODY = '<body>' . PHP_EOL;
     private const CLOSE_BODY = '</body>' . PHP_EOL;
@@ -39,9 +39,9 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
 
     public function getOutput(): string
     {
-        return parent::getOutput();
-        #$this->import(['output' => $this->buildOutputWithHtmlStructure()]);
-        #return ($this->getState() === true ? $this->export()['output'] : '');
+        #return parent::getOutput();
+        $this->import(['output' => $this->buildOutputWithHtmlStructure()]);
+        return ($this->getState() === true ? $this->export()['output'] : '');
     }
 
     private function buildOutputWithHtmlStructure(): string
@@ -68,6 +68,21 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
         return $this->webUIOutput;
     }
 
+    private function title(): string
+    {
+        return sprintf(
+            $this->titleSprint,
+            (
+                $this->getRouter()
+                     ->getRequest()
+                     ->getGet()['request']
+                ??
+                $this->getRouter()
+                     ->getRequest()
+                     ->getName()
+            )
+        );
+    }
     private function openHtml(): void
     {
         /** @devNote:
@@ -78,13 +93,8 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
             self::DOCTYPE .
             self::OPEN_HTML .
             self::OPEN_HEAD .
-            self::OPEN_TITLE .
-            (
-                $this->getRouter()->getRequest()->getGet()['request']
-                ??
-                $this->getRouter()->getRequest()->getUrl()
-            ) .
-            self::CLOSE_TITLE
+            $this->title() .
+            self::VIEWPORT
         ;
     }
 

--- a/core/abstractions/component/UserInterface/WebUI.php
+++ b/core/abstractions/component/UserInterface/WebUI.php
@@ -39,8 +39,9 @@ abstract class WebUI extends ResponseUIInterface implements WebUIInterface
 
     public function getOutput(): string
     {
-        $this->import(['output' => $this->buildOutputWithHtmlStructure()]);
-        return ($this->getState() === true ? $this->export()['output'] : '');
+        return parent::getOutput();
+        #$this->import(['output' => $this->buildOutputWithHtmlStructure()]);
+        #return ($this->getState() === true ? $this->export()['output'] : '');
     }
 
     private function buildOutputWithHtmlStructure(): string


### PR DESCRIPTION
commit 1ea2bb8d38f9de87ca113f49da078c9db9e9ce18
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed Apr 20 23:30:54 2022 -0400

    Working on addressing issue #371.
    
    https://github.com/sevidmusic/roady/issues/371
    
    Modified:
    
    -
    [`core/abstractions/component/UserInterface/WebUI.php`](https://github.com/sevidmusic/roady/blob/roady/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php)
    
    Finished re-defining expected html
    structure for output of WebUI.
    
    All tests are passing again, however,
    the WebUI is not actually testing
    that the appropriate script tags
    for js files and link tags for css
    files are being incorporated into
    the output.
    
    The WebUI is incorporating the link
    tags for the appropriate css files,
    but again there are not tests for
    this.
    
    script tags for js files are not
    incorporated or tested.
    
    [Issue](https://github.com/sevidmusic/roady/issues/373)
    was created to address the fact that the
    [`WebUITestTrait`](https://github.com/sevidmusic/roady/blob/roady/Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php)
    does not yet set up the expectation that `link`
    tags and `script` tags for appropriate `css`
    and `js` files are incorporated into a `WebUI`'s
    output.
    
    Modified:
    
    - `core/abstractions/component/UserInterface/WebUI.php`

commit b34f86783eb78164223b8d33d1adb13ac6d4138f
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed Apr 20 22:50:13 2022 -0400

    Working on addressing issue #372
    
    Modified:
    
    - `Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php`
    
    Added html meta tag for viewport to expected output.

commit eebf91f0719fd78148e135b130edad52257c5d36
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed Apr 20 12:19:01 2022 -0400

    Working on addressing issue #371, and issue #299.
    
    Do not merge this commit yet!
    
    Issue #371 is not resolved, this commit marks the
    re-implementation of the WebUITestTraits expectations
    for the html structure of the WebUI's output.
    
    Modified:
    
    - `Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php`
    - `Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php`

commit b9b9a87346ef5ca591306ca74878edee553a67bd
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed Apr 20 03:29:15 2022 -0400

    Working on the following issues, resolved issue #372:
    
    - #371
    - #372 (resolved)
    
    Modified:
    
    - `Tests/Unit/interfaces/component/UserInterface/TestTraits/ResponseUITestTrait.php`
    - `Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php`

commit 64e0bc5d619e143fd5e3bdfd951bb9a7123dbad0
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed Apr 20 00:46:49 2022 -0400

    Working on addressing issue #371.
    
    Refacotred WebUITestTrait WebU in preparation for re-write.
    
    Modified:
    
    - `Tests/Unit/interfaces/component/UserInterface/TestTraits/WebUITestTrait.php`
    - `core/abstractions/component/UserInterface/WebUI.php`