### PR TITLE
Resolved issue #388

### DIFF
--- a/tests/interfaces/constituents/IdentifiableTestTrait.php
+++ b/tests/interfaces/constituents/IdentifiableTestTrait.php
@@ -221,7 +221,7 @@ trait IdentifiableTestTrait
      * @return void
      *
      */
-    public function testIdReturnsExpectedId(): void
+    public function test_id_returns_expected_id(): void
     {
         $this->assertEquals(
             $this->expectedId(),
@@ -240,7 +240,7 @@ trait IdentifiableTestTrait
      * @return void
      *
      */
-    public function testNameReturnsExpectedName(): void
+    public function test_name_returns_expected_name(): void
     {
         $this->assertEquals(
             $this->expectedName(),
@@ -259,7 +259,7 @@ trait IdentifiableTestTrait
      * @return void
      *
      */
-    public function testTypeReturnsAnAppropriateClassString(): void
+    public function test_type_returns_an_appropriate_class_string(): void
     {
         $this->assertEquals(
             new ClassString($this->identifiableTestInstance()),

--- a/tests/interfaces/constituents/PositionableTestTrait.php
+++ b/tests/interfaces/constituents/PositionableTestTrait.php
@@ -221,7 +221,7 @@ trait PositionableTestTrait
      * @return void
      *
      */
-    public function testPositionReturnsTheExpectedPosition(): void
+    public function test_position_returns_the_expected_position(): void
     {
         $this->assertEquals(
             $this->expectedPosition(),
@@ -240,7 +240,7 @@ trait PositionableTestTrait
      * @return void
      *
      */
-    public function testModifierReturnsTheExpectedModifier(): void
+    public function test_modifier_returns_the_expected_modifier(): void
     {
         $this->assertEquals(
             $this->expectedModifier(),
@@ -260,7 +260,7 @@ trait PositionableTestTrait
      * @return void
      *
      */
-    public function testIncrementPositionIncrementsThePositionByTheModifier(): void
+    public function test_increment_position_increments_the_position_by_the_modifier(): void
     {
         $this->setExpectedPosition(
             $this->positionableTestInstance()->position()
@@ -286,7 +286,7 @@ trait PositionableTestTrait
      * @return void
      *
      */
-    public function testDecrementPositionDecrementsThePositionByTheModifier(): void
+    public function test_decrement_position_decrements_the_position_by_the_modifier(): void
     {
         $this->setExpectedPosition(
             $this->positionableTestInstance()->position()

--- a/tests/interfaces/constituents/SwitchableTestTrait.php
+++ b/tests/interfaces/constituents/SwitchableTestTrait.php
@@ -148,7 +148,7 @@ trait SwitchableTestTrait
      * @return void
      *
      */
-    public function testStateReturnsExpectedState(): void
+    public function test_state_returns_expected_state(): void
     {
         $this->assertEquals(
             $this->expectedState(),
@@ -167,7 +167,7 @@ trait SwitchableTestTrait
      * @return void
      *
      */
-    public function testSwitchStateSwtichesTheState(): void
+    public function test_switch_state_swtiches_the_state(): void
     {
         $this->setExpectedState(
             (

--- a/tests/interfaces/strings/AlphanumericTextTestTrait.php
+++ b/tests/interfaces/strings/AlphanumericTextTestTrait.php
@@ -171,7 +171,7 @@ trait AlphanumericTextTestTrait
      * @return void
      *
      */
-    public function test__toStringReturnsAnAlphanumericString(): void
+    public function test__to_string_returns_an_alphanumeric_string(): void
     {
         $this->assertTrue(
             ctype_alnum(
@@ -193,7 +193,7 @@ trait AlphanumericTextTestTrait
      * @return void
      *
      */
-    public function test__toStringReturnsAnAlphanumericFormOfTheOriginalText(): void
+    public function test__to_string_returns_an_alphanumeric_form_of_the_original_text(): void
     {
         $this->assertEquals(
             $this->makeStringSafe(

--- a/tests/interfaces/strings/IdTestTrait.php
+++ b/tests/interfaces/strings/IdTestTrait.php
@@ -120,7 +120,7 @@ trait IdTestTrait
      * @return void
      *
      */
-    public function testLengthIsGreaterThanOrEqualTo60(): void
+    public function test_length_is_greater_than_or_equal_to_60(): void
     {
         for($i = 0; $i < 1000; $i++) {
             $this->setUpWithNewInstance();
@@ -143,7 +143,7 @@ trait IdTestTrait
      * @return void
      *
      */
-    public function testLengthIsLessThanOrEqualTo80(): void
+    public function test_length_is_less_than_or_equal_to_80(): void
     {
         for($i = 0; $i < 1000; $i++) {
             $this->setUpWithNewInstance();

--- a/tests/interfaces/utilities/ReflectionTestTrait.php
+++ b/tests/interfaces/utilities/ReflectionTestTrait.php
@@ -269,7 +269,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testTypeReturnsTypeOfReflectedClass(): void
+    public function test_type_returns_type_of_reflected_class(): void
     {
         $this->assertEquals(
             (
@@ -295,7 +295,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfAllTheMethodsDefinedByTheReflectedClassIfNoFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_all_the_methods_defined_by_the_reflected_class_if_no_filter_is_specified(): void
     {
         $this->assertEquals(
             $this->determineReflectedClassesMethodNames(),
@@ -318,7 +318,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfThePrivateMethodsDefinedByTheReflectedClassIfTheReflectionClassIS_PRIVATEFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_the_private_methods_defined_by_the_reflected_class_if_the_ReflectionMethodIS_PRIVATE_filter_is_specified(): void
     {
         $filter = ReflectionMethod::IS_PRIVATE;
         $this->assertEquals(
@@ -343,7 +343,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfTheProtectedMethodsDefinedByTheReflectedClassIfTheReflectionClassIS_PROTECTEDFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_the_protected_methods_defined_by_the_reflected_class_if_the_ReflectionMethodIS_PROTECTED_filter_is_specified(): void
     {
         $filter = ReflectionMethod::IS_PROTECTED;
         $this->assertEquals(
@@ -368,7 +368,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfThePublicMethodsDefinedByTheReflectedClassIfTheReflectionClassIS_PUBLICFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_the_public_methods_defined_by_the_reflected_class_if_the_ReflectionMethodIS_PUBLIC_filter_is_specified(): void
     {
         $filter = ReflectionMethod::IS_PUBLIC;
         $this->assertEquals(
@@ -393,7 +393,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfTheAbstractMethodsDefinedByTheReflectedClassIfTheReflectionClassIS_ABSTRACTFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_the_abstract_methods_defined_by_the_reflected_class_if_the_ReflectionMethodIS_ABSTRACT_filter_is_specified(): void
     {
         $filter = ReflectionMethod::IS_ABSTRACT;
         $this->assertEquals(
@@ -418,7 +418,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfTheStaticMethodsDefinedByTheReflectedClassIfTheReflectionClassIS_STATICFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_the_static_methods_defined_by_the_reflected_class_if_the_ReflectionMethodIS_STATIC_filter_is_specified(): void
     {
         $filter = ReflectionMethod::IS_STATIC;
         $this->assertEquals(
@@ -443,7 +443,7 @@ trait ReflectionTestTrait
      * @return void
      *
      */
-    public function testMethodNamesReturnsTheNamesOfTheFinalMethodsDefinedByTheReflectedClassIfTheReflectionClassIS_FINALFilterIsSpecified(): void
+    public function test_method_names_returns_the_names_of_the_final_methods_defined_by_the_reflected_class_if_the_ReflectionMethodIS_FINAL_filter_is_specified(): void
     {
         $filter = ReflectionMethod::IS_FINAL;
         $this->assertEquals(


### PR DESCRIPTION
Resolved issue #388

[Issue #388](https://github.com/sevidmusic/roady/issues/388)

Test methods defined in the following files now meet the coding style standards for naming test methods:

```
tests/interfaces/constituents/IdentifiableTestTrait.php
tests/interfaces/constituents/PositionableTestTrait.php
tests/interfaces/constituents/SwitchableTestTrait.php
tests/interfaces/strings/AlphanumericTextTestTrait.php
tests/interfaces/strings/IdTestTrait.php
tests/interfaces/utilities/ReflectionTestTrait.php

```